### PR TITLE
로또 자동화 안정성·동시성·스케줄러 개선 (v9.3.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,37 @@ services:
       - LOTTO_ID=your_lotto_id
       - LOTTO_PASSWORD=your_lotto_password
       - LOTTO_EMAIL=your_email
-
 ```
 
 ## Environment
 
-| Key            | Description   | Example             |
-|----------------|---------------|---------------------|
-| MAIL_USERNAME       | SMTP 이메일 아이디  | your_email_id       |
-| MAIL_PASSWORD | SMTP 이메일 비밀번호 | your_email_password |
-| LOTTO_ID       | 로또 사이트 아이디    | your_lotto_id       |
-| LOTTO_PASSWORD | 로또 사이트 비밀번호   | your_lotto_password |
-| LOTTO_EMAIL    | 로또 결과 확인 이메일  | your_email          |
-| LOTTO_COUNT    | 로또 구매 개수      | 1 ~ 5               |
+| Key            | Description                                 | Example             |
+|----------------|---------------------------------------------|---------------------|
+| MAIL_USERNAME  | SMTP 이메일 아이디 (`spring.mail.username`)  | your_email_id       |
+| MAIL_PASSWORD  | SMTP 이메일 비밀번호 (`spring.mail.password`) | your_email_password |
+| LOTTO_ID       | 로또 사이트 아이디 (`lotto.users[*].id`)      | your_lotto_id       |
+| LOTTO_PASSWORD | 로또 사이트 비밀번호 (`lotto.users[*].password`) | your_lotto_password |
+| LOTTO_EMAIL    | 로또 결과 확인 이메일 (`lotto.users[*].email`) | your_email          |
+| LOTTO_COUNT    | 로또 구매 개수 (`lotto.users[*].count`)       | 1 ~ 5               |
+
+> 위 환경변수(`MAIL_*`, `LOTTO_*`)와 `lotto.*` 설정은 platform의 Spring Config Server
+> (`spring.config.import`)에서 주입하는 것을 기본 전제로 합니다.
+> 로컬에서 Config Server 없이 실행할 경우에는 별도 `application-local.yaml`(local 프로파일)을 두어 오버라이드합니다.
+
+### 주요 `lotto.*` 튜닝 설정
+
+| Key                                    | 기본값        | 설명                                          |
+|----------------------------------------|--------------|---------------------------------------------|
+| lotto.max-retries                      | 3            | 조회성 브라우저 작업(login/check) 재시도 횟수. 구매(buy)는 재시도하지 않음 |
+| lotto.retry-delay-ms                   | 2000         | 재시도 지연(ms)                                   |
+| lotto.purchase-result-timeout-ms       | 30000        | 구매 후 원장 확인 폴링 총 타임아웃(ms)                      |
+| lotto.purchase-result-poll-interval-ms | 1000         | 구매 후 원장 확인 폴링 간격(ms)                         |
+| lotto.max-concurrent-sessions          | 3            | 동시에 띄우는 Playwright 브라우저 세션 상한                 |
+| lotto.user-task-timeout-ms             | 180000       | 사용자 1인 작업(login→구매→확인)의 최대 실행 시간(ms)          |
+| lotto.trace-enabled                    | false        | Playwright 트레이스 저장 여부. 민감정보 캡처 위험으로 기본 비활성화   |
+| lotto.cron.check                       | 0 0 22 * * 6 | 결과 확인 스케줄 cron                              |
+| lotto.cron.buy                         | 0 0 9 * * 0  | 구매 스케줄 cron                                |
+| lotto.cron.zone                        | Asia/Seoul   | 스케줄러 타임존                                   |
 
 ## API
 
@@ -48,9 +66,17 @@ services:
 - 다중 유저 실행: `POST /api/lotto/buy?userId=user1&userId=user2`
 - 유효하지 않은 `userId` 포함 시 `400 Bad Request` 반환
 
+> 인증/인가는 애플리케이션 앞단의 게이트웨이에서 처리합니다. (서비스 자체에는 인증 로직을 두지 않습니다.)
+
+## 실행 안전장치
+
+- **구매 비멱등 보호**: 구매(`buy`)에는 재시도를 적용하지 않습니다. 최종 확정 이후 실패 시 중복 구매를 막기 위함이며, 실제 반영 여부는 구매 후 원장 확인으로 검증합니다.
+- **중복 실행 방지**: 동일 사용자·모드 작업이 인스턴스 내에서 동시에 중복 실행되지 않도록 in-flight 가드를 둡니다. (다중 인스턴스 배포 시에는 분산 락/리더 선출이 별도로 필요합니다.)
+- **동시성 상한**: `lotto.max-concurrent-sessions`로 동시에 뜨는 브라우저 세션 수를 제한합니다.
+- **작업 타임아웃**: 사용자 작업이 `lotto.user-task-timeout-ms`를 초과하면 실패로 처리합니다.
+
 ## Config Refresh
 
-- `LottoProperties`는 `@RefreshScope`로 적용되어 `lotto.*` 변경값을 런타임에 반영합니다.
-- 스케줄러는 고정 `@Scheduled`가 아닌 동적 Trigger 방식으로 동작하여 refresh 이후 변경된 cron을 다음 실행 계산부터 사용합니다.
-- Actuator refresh endpoint 노출:
-    - `POST /actuator/refresh`
+- `LottoProperties`(`@ConfigurationProperties`)는 `POST /actuator/refresh` 시 재바인딩되어 `lotto.*` 변경값을 런타임에 반영합니다.
+- 스케줄러는 고정 `@Scheduled`가 아닌 동적 Trigger(`SchedulingConfigurer`)로 동작하여, 매 다음 실행 계산 시점에 현재 `lotto.cron.*`(및 `lotto.cron.zone`)를 다시 읽습니다. 따라서 refresh 이후 변경된 cron이 다음 실행부터 반영됩니다.
+- Actuator refresh endpoint: `POST /actuator/refresh`

--- a/README.md
+++ b/README.md
@@ -75,8 +75,7 @@ services:
 - **동시성 상한**: `lotto.max-concurrent-sessions`로 동시에 뜨는 브라우저 세션 수를 제한합니다.
 - **작업 타임아웃**: 사용자 작업이 `lotto.user-task-timeout-ms`를 초과하면 실패로 처리합니다.
 
-## Config Refresh
+## Config
 
-- `LottoProperties`(`@ConfigurationProperties`)는 `POST /actuator/refresh` 시 재바인딩되어 `lotto.*` 변경값을 런타임에 반영합니다.
-- 스케줄러는 고정 `@Scheduled`가 아닌 동적 Trigger(`SchedulingConfigurer`)로 동작하여, 매 다음 실행 계산 시점에 현재 `lotto.cron.*`(및 `lotto.cron.zone`)를 다시 읽습니다. 따라서 refresh 이후 변경된 cron이 다음 실행부터 반영됩니다.
-- Actuator refresh endpoint: `POST /actuator/refresh`
+- `LottoProperties`(`@ConfigurationProperties`)는 기동 시 `lotto.*` 설정을 바인딩합니다.
+- 스케줄러는 `@Scheduled`로 동작하며, `lotto.cron.*` 및 `lotto.cron.zone` 값은 애플리케이션 기동 시점에 적용됩니다.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ services:
 > 위 환경변수(`MAIL_*`, `LOTTO_*`)와 `lotto.*` 설정은 platform의 Spring Config Server
 > (`spring.config.import`)에서 주입하는 것을 기본 전제로 합니다.
 > 로컬에서 Config Server 없이 실행할 경우에는 별도 `application-local.yaml`(local 프로파일)을 두어 오버라이드합니다.
+> `bootRun`은 별도 지정이 없으면 `local` 프로파일로 실행됩니다.
 
 ### 주요 `lotto.*` 튜닝 설정
 
@@ -47,7 +48,6 @@ services:
 | lotto.purchase-result-poll-interval-ms | 1000         | 구매 후 원장 확인 폴링 간격(ms)                         |
 | lotto.max-concurrent-sessions          | 3            | 동시에 띄우는 Playwright 브라우저 세션 상한                 |
 | lotto.user-task-timeout-ms             | 180000       | 사용자 1인 작업(login→구매→확인)의 최대 실행 시간(ms)          |
-| lotto.trace-enabled                    | false        | Playwright 트레이스 저장 여부. 민감정보 캡처 위험으로 기본 비활성화   |
 | lotto.cron.check                       | 0 0 22 * * 6 | 결과 확인 스케줄 cron                              |
 | lotto.cron.buy                         | 0 0 9 * * 0  | 구매 스케줄 cron                                |
 | lotto.cron.zone                        | Asia/Seoul   | 스케줄러 타임존                                   |
@@ -74,6 +74,7 @@ services:
 - **중복 실행 방지**: 동일 사용자·모드 작업이 인스턴스 내에서 동시에 중복 실행되지 않도록 in-flight 가드를 둡니다. (다중 인스턴스 배포 시에는 분산 락/리더 선출이 별도로 필요합니다.)
 - **동시성 상한**: `lotto.max-concurrent-sessions`로 동시에 뜨는 브라우저 세션 수를 제한합니다.
 - **작업 타임아웃**: 사용자 작업이 `lotto.user-task-timeout-ms`를 초과하면 실패로 처리합니다.
+- **실패 트레이스**: Playwright trace는 세션 중 항상 수집하되, 정상 종료 시 폐기하고 실패 시에만 `lotto-trace-*.zip`으로 저장합니다.
 
 ## Config
 

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.nowstart'
-version = '9.2.1'
+version = '9.3.0'
 
 springBoot {
     buildInfo()

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ tasks.named('test') {
     useJUnitPlatform()
 }
 
+bootRun {
+    systemProperty 'spring.profiles.active',
+            System.getProperty('spring.profiles.active', System.getenv('SPRING_PROFILES_ACTIVE') ?: 'local')
+}
+
 bootBuildImage {
     runImage = "mcr.microsoft.com/playwright/java:v$playwrightVersion"
 

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -8,6 +8,7 @@ import org.nowstart.lotto.application.port.in.LottoUseCase;
 import org.nowstart.lotto.application.port.in.LottoUseCase.TargetCommand;
 import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.domain.type.TriggerType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.scheduling.TriggerContext;
 import org.springframework.scheduling.annotation.SchedulingConfigurer;
 import org.springframework.scheduling.config.ScheduledTaskRegistrar;
@@ -17,9 +18,13 @@ import org.springframework.stereotype.Component;
 /**
  * 정적 @Scheduled 대신 동적 Trigger로 등록한다. 매 실행 계산 시점에 LottoProperties의 현재 cron을 다시 읽으므로,
  * Config Server refresh(@ConfigurationProperties 재바인딩) 이후 변경된 cron이 다음 실행부터 반영된다.
+ *
+ * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
+ * 로컬에서는 수동 API(POST /api/lotto/check, /api/lotto/buy)로 실행한다.
  */
 @Slf4j
 @Component
+@Profile("!local")
 @RequiredArgsConstructor
 public class LottoScheduleExecutor implements SchedulingConfigurer {
 

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -1,29 +1,53 @@
 package org.nowstart.lotto.adapter.in.scheduler;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.in.LottoUseCase;
 import org.nowstart.lotto.application.port.in.LottoUseCase.TargetCommand;
+import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.domain.type.TriggerType;
-import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.scheduling.TriggerContext;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
+import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
+/**
+ * 정적 @Scheduled 대신 동적 Trigger로 등록한다. 매 실행 계산 시점에 LottoProperties의 현재 cron을 다시 읽으므로,
+ * Config Server refresh(@ConfigurationProperties 재바인딩) 이후 변경된 cron이 다음 실행부터 반영된다.
+ */
 @Slf4j
 @Component
 @RequiredArgsConstructor
-public class LottoScheduleExecutor {
+public class LottoScheduleExecutor implements SchedulingConfigurer {
 
     private final LottoUseCase lottoUseCase;
+    private final LottoProperties lottoProperties;
 
-    @Scheduled(cron = "${lotto.cron.check}")
-    public void checkLottoResults() {
+    @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.addTriggerTask(
+                this::checkLottoResults,
+                triggerContext -> nextExecution(lottoProperties.getCron().getCheck(), triggerContext));
+        taskRegistrar.addTriggerTask(
+                this::buyLottoTickets,
+                triggerContext -> nextExecution(lottoProperties.getCron().getBuy(), triggerContext));
+    }
+
+    void checkLottoResults() {
         log.info("[Schedule] Check Start");
         lottoUseCase.check(TargetCommand.all(TriggerType.SCHEDULE));
     }
 
-    @Scheduled(cron = "${lotto.cron.buy}")
-    public void buyLottoTickets() {
+    void buyLottoTickets() {
         log.info("[Schedule] Purchase Start");
         lottoUseCase.purchase(TargetCommand.all(TriggerType.SCHEDULE));
+    }
+
+    private Instant nextExecution(String cronExpression, TriggerContext triggerContext) {
+        ZoneId zone = ZoneId.of(lottoProperties.getCron().getZone());
+        return new CronTrigger(cronExpression, zone).nextExecution(triggerContext);
     }
 }

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -2,13 +2,11 @@ package org.nowstart.lotto.adapter.in.scheduler;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.in.LottoUseCase;
@@ -26,12 +24,11 @@ import org.springframework.stereotype.Component;
 
 /**
  * 동적 Trigger로 등록하되, cron 변경 반영을 위해 직접 스케줄을 관리한다.
- * - 매 실행 계산 시점에 LottoProperties의 현재 cron/zone을 다시 읽는다.
  * - /actuator/refresh(RefreshScopeRefreshedEvent) 시 기존 예약을 취소하고 즉시 재등록한다.
  * - 재등록 시 generation을 올려, 실행 중이라 cancel(false)로 못 막은 이전 트리거가 재예약을 시도할 때
  *   nextExecution이 null을 반환하도록 하여 옛/새 cron이 동시에 발화하는 중복 실행을 방지한다.
- * - 재등록 전 새 cron/zone을 먼저 검증한다. 잘못된 값이면 기존 스케줄을 그대로 유지해, refresh 오타로
- *   스케줄러가 통째로 멈추는 것을 방지한다.
+ * - 재등록 전 새 cron/zone을 검증하고, 잘못되면 기존 스케줄을 유지한다. 이때 유지되는 트리거는 등록 시점에
+ *   '검증된' cron/zone을 캡처해 사용하므로, live(무효) 값을 다시 읽어 실패하는 일이 없다(마지막 정상 스케줄 유지).
  *
  * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
  */
@@ -70,11 +67,13 @@ public class LottoScheduleExecutor {
         String buy = lottoProperties.getCron().getBuy();
         String zoneId = lottoProperties.getCron().getZone();
 
-        // 취소/재등록 전에 새 cron·zone을 검증한다. 잘못되면 기존 스케줄을 유지한다.
+        // 취소/재등록 전에 새 cron·zone을 검증하고, 유효한 값만 캡처한다. 잘못되면 기존 스케줄을 유지한다.
+        CronTrigger checkTrigger;
+        CronTrigger buyTrigger;
         try {
             ZoneId zone = ZoneId.of(zoneId);
-            new CronTrigger(check, zone);
-            new CronTrigger(buy, zone);
+            checkTrigger = new CronTrigger(check, zone);
+            buyTrigger = new CronTrigger(buy, zone);
         } catch (RuntimeException exception) {
             log.error("[Schedule] Invalid cron/zone - keeping previous schedule (check={}, buy={}, zone={})",
                     check, buy, zoneId, exception);
@@ -83,10 +82,11 @@ public class LottoScheduleExecutor {
 
         long currentGeneration = generation.incrementAndGet();
         cancelAll();
+        // 트리거에 '검증된' CronTrigger 인스턴스를 캡처해 넘긴다 — 이후 live 프로퍼티(무효일 수 있음)를 다시 읽지 않는다.
         scheduledTasks.add(taskScheduler.schedule(this::checkLottoResults,
-                generationAwareTrigger(currentGeneration, () -> lottoProperties.getCron().getCheck())));
+                generationAwareTrigger(currentGeneration, checkTrigger)));
         scheduledTasks.add(taskScheduler.schedule(this::buyLottoTickets,
-                generationAwareTrigger(currentGeneration, () -> lottoProperties.getCron().getBuy())));
+                generationAwareTrigger(currentGeneration, buyTrigger)));
         log.info("[Schedule] Registered check/buy triggers (gen={}, check={}, buy={}, zone={})",
                 currentGeneration, check, buy, zoneId);
     }
@@ -106,18 +106,13 @@ public class LottoScheduleExecutor {
         scheduledTasks.clear();
     }
 
-    private Trigger generationAwareTrigger(long ownedGeneration, Supplier<String> cronExpressionSupplier) {
+    private Trigger generationAwareTrigger(long ownedGeneration, CronTrigger cronTrigger) {
         return (TriggerContext triggerContext) -> {
             if (ownedGeneration != generation.get()) {
                 // refresh로 대체된(오래된) 트리거 — 재예약을 중단해 중복 발화를 막는다.
                 return null;
             }
-            return nextExecution(cronExpressionSupplier.get(), triggerContext);
+            return cronTrigger.nextExecution(triggerContext);
         };
-    }
-
-    private Instant nextExecution(String cronExpression, TriggerContext triggerContext) {
-        ZoneId zone = ZoneId.of(lottoProperties.getCron().getZone());
-        return new CronTrigger(cronExpression, zone).nextExecution(triggerContext);
     }
 }

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -30,6 +30,8 @@ import org.springframework.stereotype.Component;
  * - /actuator/refresh(RefreshScopeRefreshedEvent) 시 기존 예약을 취소하고 즉시 재등록한다.
  * - 재등록 시 generation을 올려, 실행 중이라 cancel(false)로 못 막은 이전 트리거가 재예약을 시도할 때
  *   nextExecution이 null을 반환하도록 하여 옛/새 cron이 동시에 발화하는 중복 실행을 방지한다.
+ * - 재등록 전 새 cron/zone을 먼저 검증한다. 잘못된 값이면 기존 스케줄을 그대로 유지해, refresh 오타로
+ *   스케줄러가 통째로 멈추는 것을 방지한다.
  *
  * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
  */
@@ -48,6 +50,37 @@ public class LottoScheduleExecutor {
 
     @PostConstruct
     public synchronized void scheduleAll() {
+        reschedule();
+    }
+
+    @EventListener(RefreshScopeRefreshedEvent.class)
+    public synchronized void onRefresh(RefreshScopeRefreshedEvent event) {
+        log.info("[Schedule] Refresh detected - rescheduling with current cron");
+        reschedule();
+    }
+
+    @PreDestroy
+    public synchronized void shutdown() {
+        generation.incrementAndGet();
+        cancelAll();
+    }
+
+    private void reschedule() {
+        String check = lottoProperties.getCron().getCheck();
+        String buy = lottoProperties.getCron().getBuy();
+        String zoneId = lottoProperties.getCron().getZone();
+
+        // 취소/재등록 전에 새 cron·zone을 검증한다. 잘못되면 기존 스케줄을 유지한다.
+        try {
+            ZoneId zone = ZoneId.of(zoneId);
+            new CronTrigger(check, zone);
+            new CronTrigger(buy, zone);
+        } catch (RuntimeException exception) {
+            log.error("[Schedule] Invalid cron/zone - keeping previous schedule (check={}, buy={}, zone={})",
+                    check, buy, zoneId, exception);
+            return;
+        }
+
         long currentGeneration = generation.incrementAndGet();
         cancelAll();
         scheduledTasks.add(taskScheduler.schedule(this::checkLottoResults,
@@ -55,22 +88,7 @@ public class LottoScheduleExecutor {
         scheduledTasks.add(taskScheduler.schedule(this::buyLottoTickets,
                 generationAwareTrigger(currentGeneration, () -> lottoProperties.getCron().getBuy())));
         log.info("[Schedule] Registered check/buy triggers (gen={}, check={}, buy={}, zone={})",
-                currentGeneration,
-                lottoProperties.getCron().getCheck(),
-                lottoProperties.getCron().getBuy(),
-                lottoProperties.getCron().getZone());
-    }
-
-    @EventListener(RefreshScopeRefreshedEvent.class)
-    public synchronized void onRefresh(RefreshScopeRefreshedEvent event) {
-        log.info("[Schedule] Refresh detected - rescheduling with current cron");
-        scheduleAll();
-    }
-
-    @PreDestroy
-    public synchronized void shutdown() {
-        generation.incrementAndGet();
-        cancelAll();
+                currentGeneration, check, buy, zoneId);
     }
 
     void checkLottoResults() {

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -20,13 +20,13 @@ public class LottoScheduleExecutor {
 
     private final LottoUseCase lottoUseCase;
 
-    @Scheduled(cron = "${lotto.cron.check}", zone = "${lotto.cron.zone}")
+    @Scheduled(cron = "${lotto.cron.check}", zone = "${lotto.cron.zone:Asia/Seoul}")
     public void checkLottoResults() {
         log.info("[Schedule] Check Start");
         lottoUseCase.check(TargetCommand.all(TriggerType.SCHEDULE));
     }
 
-    @Scheduled(cron = "${lotto.cron.buy}", zone = "${lotto.cron.zone}")
+    @Scheduled(cron = "${lotto.cron.buy}", zone = "${lotto.cron.zone:Asia/Seoul}")
     public void buyLottoTickets() {
         log.info("[Schedule] Purchase Start");
         lottoUseCase.purchase(TargetCommand.all(TriggerType.SCHEDULE));

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -1,44 +1,69 @@
 package org.nowstart.lotto.adapter.in.scheduler;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ScheduledFuture;
+import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.in.LottoUseCase;
 import org.nowstart.lotto.application.port.in.LottoUseCase.TargetCommand;
 import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.domain.type.TriggerType;
-import org.springframework.context.annotation.Profile;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.TriggerContext;
-import org.springframework.scheduling.annotation.SchedulingConfigurer;
-import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
 /**
- * 정적 @Scheduled 대신 동적 Trigger로 등록한다. 매 실행 계산 시점에 LottoProperties의 현재 cron을 다시 읽으므로,
- * Config Server refresh(@ConfigurationProperties 재바인딩) 이후 변경된 cron이 다음 실행부터 반영된다.
+ * 동적 Trigger로 등록하되, cron 변경 반영을 위해 직접 스케줄을 관리한다.
+ * - 매 실행 계산 시점에 LottoProperties의 현재 cron/zone을 다시 읽는다.
+ * - /actuator/refresh 시 발생하는 RefreshScopeRefreshedEvent를 수신해 기존 예약을 취소하고 즉시 재등록한다.
+ *   (재등록하지 않으면 이미 계산된 다음 실행은 옛 cron으로 유지되고, 그 이후 실행부터만 새 cron이 반영된다.)
  *
  * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
- * 로컬에서는 수동 API(POST /api/lotto/check, /api/lotto/buy)로 실행한다.
  */
 @Slf4j
 @Component
-@Profile("!local")
+@org.springframework.context.annotation.Profile("!local")
 @RequiredArgsConstructor
-public class LottoScheduleExecutor implements SchedulingConfigurer {
+public class LottoScheduleExecutor {
 
     private final LottoUseCase lottoUseCase;
     private final LottoProperties lottoProperties;
+    private final TaskScheduler taskScheduler;
 
-    @Override
-    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-        taskRegistrar.addTriggerTask(
-                this::checkLottoResults,
-                triggerContext -> nextExecution(lottoProperties.getCron().getCheck(), triggerContext));
-        taskRegistrar.addTriggerTask(
-                this::buyLottoTickets,
-                triggerContext -> nextExecution(lottoProperties.getCron().getBuy(), triggerContext));
+    private final List<ScheduledFuture<?>> scheduledTasks = new CopyOnWriteArrayList<>();
+
+    @PostConstruct
+    public synchronized void scheduleAll() {
+        cancelAll();
+        scheduledTasks.add(taskScheduler.schedule(this::checkLottoResults,
+                triggerFor(() -> lottoProperties.getCron().getCheck())));
+        scheduledTasks.add(taskScheduler.schedule(this::buyLottoTickets,
+                triggerFor(() -> lottoProperties.getCron().getBuy())));
+        log.info("[Schedule] Registered check/buy triggers (check={}, buy={}, zone={})",
+                lottoProperties.getCron().getCheck(),
+                lottoProperties.getCron().getBuy(),
+                lottoProperties.getCron().getZone());
+    }
+
+    @EventListener(RefreshScopeRefreshedEvent.class)
+    public synchronized void onRefresh(RefreshScopeRefreshedEvent event) {
+        log.info("[Schedule] Refresh detected - rescheduling with current cron");
+        scheduleAll();
+    }
+
+    @PreDestroy
+    public synchronized void shutdown() {
+        cancelAll();
     }
 
     void checkLottoResults() {
@@ -49,6 +74,15 @@ public class LottoScheduleExecutor implements SchedulingConfigurer {
     void buyLottoTickets() {
         log.info("[Schedule] Purchase Start");
         lottoUseCase.purchase(TargetCommand.all(TriggerType.SCHEDULE));
+    }
+
+    private void cancelAll() {
+        scheduledTasks.forEach(task -> task.cancel(false));
+        scheduledTasks.clear();
+    }
+
+    private Trigger triggerFor(Supplier<String> cronExpressionSupplier) {
+        return (TriggerContext triggerContext) -> nextExecution(cronExpressionSupplier.get(), triggerContext);
     }
 
     private Instant nextExecution(String cronExpression, TriggerContext triggerContext) {

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -7,6 +7,7 @@ import java.time.ZoneId;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -15,6 +16,7 @@ import org.nowstart.lotto.application.port.in.LottoUseCase.TargetCommand;
 import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.domain.type.TriggerType;
 import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.TaskScheduler;
 import org.springframework.scheduling.Trigger;
@@ -25,14 +27,15 @@ import org.springframework.stereotype.Component;
 /**
  * 동적 Trigger로 등록하되, cron 변경 반영을 위해 직접 스케줄을 관리한다.
  * - 매 실행 계산 시점에 LottoProperties의 현재 cron/zone을 다시 읽는다.
- * - /actuator/refresh 시 발생하는 RefreshScopeRefreshedEvent를 수신해 기존 예약을 취소하고 즉시 재등록한다.
- *   (재등록하지 않으면 이미 계산된 다음 실행은 옛 cron으로 유지되고, 그 이후 실행부터만 새 cron이 반영된다.)
+ * - /actuator/refresh(RefreshScopeRefreshedEvent) 시 기존 예약을 취소하고 즉시 재등록한다.
+ * - 재등록 시 generation을 올려, 실행 중이라 cancel(false)로 못 막은 이전 트리거가 재예약을 시도할 때
+ *   nextExecution이 null을 반환하도록 하여 옛/새 cron이 동시에 발화하는 중복 실행을 방지한다.
  *
  * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
  */
 @Slf4j
 @Component
-@org.springframework.context.annotation.Profile("!local")
+@Profile("!local")
 @RequiredArgsConstructor
 public class LottoScheduleExecutor {
 
@@ -41,15 +44,18 @@ public class LottoScheduleExecutor {
     private final TaskScheduler taskScheduler;
 
     private final List<ScheduledFuture<?>> scheduledTasks = new CopyOnWriteArrayList<>();
+    private final AtomicLong generation = new AtomicLong(0);
 
     @PostConstruct
     public synchronized void scheduleAll() {
+        long currentGeneration = generation.incrementAndGet();
         cancelAll();
         scheduledTasks.add(taskScheduler.schedule(this::checkLottoResults,
-                triggerFor(() -> lottoProperties.getCron().getCheck())));
+                generationAwareTrigger(currentGeneration, () -> lottoProperties.getCron().getCheck())));
         scheduledTasks.add(taskScheduler.schedule(this::buyLottoTickets,
-                triggerFor(() -> lottoProperties.getCron().getBuy())));
-        log.info("[Schedule] Registered check/buy triggers (check={}, buy={}, zone={})",
+                generationAwareTrigger(currentGeneration, () -> lottoProperties.getCron().getBuy())));
+        log.info("[Schedule] Registered check/buy triggers (gen={}, check={}, buy={}, zone={})",
+                currentGeneration,
                 lottoProperties.getCron().getCheck(),
                 lottoProperties.getCron().getBuy(),
                 lottoProperties.getCron().getZone());
@@ -63,6 +69,7 @@ public class LottoScheduleExecutor {
 
     @PreDestroy
     public synchronized void shutdown() {
+        generation.incrementAndGet();
         cancelAll();
     }
 
@@ -81,8 +88,14 @@ public class LottoScheduleExecutor {
         scheduledTasks.clear();
     }
 
-    private Trigger triggerFor(Supplier<String> cronExpressionSupplier) {
-        return (TriggerContext triggerContext) -> nextExecution(cronExpressionSupplier.get(), triggerContext);
+    private Trigger generationAwareTrigger(long ownedGeneration, Supplier<String> cronExpressionSupplier) {
+        return (TriggerContext triggerContext) -> {
+            if (ownedGeneration != generation.get()) {
+                // refresh로 대체된(오래된) 트리거 — 재예약을 중단해 중복 발화를 막는다.
+                return null;
+            }
+            return nextExecution(cronExpressionSupplier.get(), triggerContext);
+        };
     }
 
     private Instant nextExecution(String cronExpression, TriggerContext triggerContext) {

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -1,35 +1,15 @@
 package org.nowstart.lotto.adapter.in.scheduler;
 
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
-import java.time.ZoneId;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ScheduledFuture;
-import java.util.concurrent.atomic.AtomicLong;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.in.LottoUseCase;
 import org.nowstart.lotto.application.port.in.LottoUseCase.TargetCommand;
-import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.domain.type.TriggerType;
-import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
 import org.springframework.context.annotation.Profile;
-import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.TaskScheduler;
-import org.springframework.scheduling.Trigger;
-import org.springframework.scheduling.TriggerContext;
-import org.springframework.scheduling.support.CronTrigger;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 동적 Trigger로 등록하되 직접 스케줄을 관리한다.
- * - /actuator/refresh(RefreshScopeRefreshedEvent) 시 기존 예약을 취소하고 즉시 재등록한다.
- * - 재등록 시 generation을 올려, cancel(false)로 못 막은 실행 중 이전 트리거가 재예약 시 null을 반환하게 하여 중복 발화를 막는다.
- * - 재등록 전 새 cron/zone을 검증하고, 등록 시점의 '검증된' CronTrigger를 캡처한다.
- * - 초기(@PostConstruct) 등록이 실패하면 유지할 이전 스케줄이 없으므로 fail-fast(예외 전파)한다.
- *   이후 refresh 실패는 마지막 정상 스케줄을 유지한다.
- *
  * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
  */
 @Slf4j
@@ -39,84 +19,16 @@ import org.springframework.stereotype.Component;
 public class LottoScheduleExecutor {
 
     private final LottoUseCase lottoUseCase;
-    private final LottoProperties lottoProperties;
-    private final TaskScheduler taskScheduler;
 
-    private final List<ScheduledFuture<?>> scheduledTasks = new CopyOnWriteArrayList<>();
-    private final AtomicLong generation = new AtomicLong(0);
-
-    @PostConstruct
-    public synchronized void scheduleAll() {
-        reschedule(true);
-    }
-
-    @EventListener(RefreshScopeRefreshedEvent.class)
-    public synchronized void onRefresh(RefreshScopeRefreshedEvent event) {
-        log.info("[Schedule] Refresh detected - rescheduling with current cron");
-        reschedule(false);
-    }
-
-    @PreDestroy
-    public synchronized void shutdown() {
-        generation.incrementAndGet();
-        cancelAll();
-    }
-
-    private void reschedule(boolean failFastOnInvalid) {
-        String check = lottoProperties.getCron().getCheck();
-        String buy = lottoProperties.getCron().getBuy();
-        String zoneId = lottoProperties.getCron().getZone();
-
-        // 취소/재등록 전에 새 cron·zone을 검증하고, 유효한 값만 캡처한다.
-        CronTrigger checkTrigger;
-        CronTrigger buyTrigger;
-        try {
-            ZoneId zone = ZoneId.of(zoneId);
-            checkTrigger = new CronTrigger(check, zone);
-            buyTrigger = new CronTrigger(buy, zone);
-        } catch (RuntimeException exception) {
-            if (failFastOnInvalid) {
-                // 초기 등록 실패: 유지할 이전 스케줄이 없으므로 fail-fast — 스케줄러가 조용히 비활성화되는 것을 막는다.
-                throw new IllegalStateException(
-                        "초기 스케줄 cron/zone 설정이 유효하지 않습니다 (check=" + check + ", buy=" + buy
-                                + ", zone=" + zoneId + ")", exception);
-            }
-            log.error("[Schedule] Invalid cron/zone on refresh - keeping previous schedule (check={}, buy={}, zone={})",
-                    check, buy, zoneId, exception);
-            return;
-        }
-
-        long currentGeneration = generation.incrementAndGet();
-        cancelAll();
-        scheduledTasks.add(taskScheduler.schedule(this::checkLottoResults,
-                generationAwareTrigger(currentGeneration, checkTrigger)));
-        scheduledTasks.add(taskScheduler.schedule(this::buyLottoTickets,
-                generationAwareTrigger(currentGeneration, buyTrigger)));
-        log.info("[Schedule] Registered check/buy triggers (gen={}, check={}, buy={}, zone={})",
-                currentGeneration, check, buy, zoneId);
-    }
-
-    void checkLottoResults() {
+    @Scheduled(cron = "${lotto.cron.check}", zone = "${lotto.cron.zone}")
+    public void checkLottoResults() {
         log.info("[Schedule] Check Start");
         lottoUseCase.check(TargetCommand.all(TriggerType.SCHEDULE));
     }
 
-    void buyLottoTickets() {
+    @Scheduled(cron = "${lotto.cron.buy}", zone = "${lotto.cron.zone}")
+    public void buyLottoTickets() {
         log.info("[Schedule] Purchase Start");
         lottoUseCase.purchase(TargetCommand.all(TriggerType.SCHEDULE));
-    }
-
-    private void cancelAll() {
-        scheduledTasks.forEach(task -> task.cancel(false));
-        scheduledTasks.clear();
-    }
-
-    private Trigger generationAwareTrigger(long ownedGeneration, CronTrigger cronTrigger) {
-        return (TriggerContext triggerContext) -> {
-            if (ownedGeneration != generation.get()) {
-                return null;
-            }
-            return cronTrigger.nextExecution(triggerContext);
-        };
     }
 }

--- a/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/in/scheduler/LottoScheduleExecutor.java
@@ -23,12 +23,12 @@ import org.springframework.scheduling.support.CronTrigger;
 import org.springframework.stereotype.Component;
 
 /**
- * 동적 Trigger로 등록하되, cron 변경 반영을 위해 직접 스케줄을 관리한다.
+ * 동적 Trigger로 등록하되 직접 스케줄을 관리한다.
  * - /actuator/refresh(RefreshScopeRefreshedEvent) 시 기존 예약을 취소하고 즉시 재등록한다.
- * - 재등록 시 generation을 올려, 실행 중이라 cancel(false)로 못 막은 이전 트리거가 재예약을 시도할 때
- *   nextExecution이 null을 반환하도록 하여 옛/새 cron이 동시에 발화하는 중복 실행을 방지한다.
- * - 재등록 전 새 cron/zone을 검증하고, 잘못되면 기존 스케줄을 유지한다. 이때 유지되는 트리거는 등록 시점에
- *   '검증된' cron/zone을 캡처해 사용하므로, live(무효) 값을 다시 읽어 실패하는 일이 없다(마지막 정상 스케줄 유지).
+ * - 재등록 시 generation을 올려, cancel(false)로 못 막은 실행 중 이전 트리거가 재예약 시 null을 반환하게 하여 중복 발화를 막는다.
+ * - 재등록 전 새 cron/zone을 검증하고, 등록 시점의 '검증된' CronTrigger를 캡처한다.
+ * - 초기(@PostConstruct) 등록이 실패하면 유지할 이전 스케줄이 없으므로 fail-fast(예외 전파)한다.
+ *   이후 refresh 실패는 마지막 정상 스케줄을 유지한다.
  *
  * local 프로파일에서는 비활성화한다 — 로컬 실행 중 스케줄러가 실제 구매/확인을 자동 트리거하는 사고를 막기 위함.
  */
@@ -47,13 +47,13 @@ public class LottoScheduleExecutor {
 
     @PostConstruct
     public synchronized void scheduleAll() {
-        reschedule();
+        reschedule(true);
     }
 
     @EventListener(RefreshScopeRefreshedEvent.class)
     public synchronized void onRefresh(RefreshScopeRefreshedEvent event) {
         log.info("[Schedule] Refresh detected - rescheduling with current cron");
-        reschedule();
+        reschedule(false);
     }
 
     @PreDestroy
@@ -62,12 +62,12 @@ public class LottoScheduleExecutor {
         cancelAll();
     }
 
-    private void reschedule() {
+    private void reschedule(boolean failFastOnInvalid) {
         String check = lottoProperties.getCron().getCheck();
         String buy = lottoProperties.getCron().getBuy();
         String zoneId = lottoProperties.getCron().getZone();
 
-        // 취소/재등록 전에 새 cron·zone을 검증하고, 유효한 값만 캡처한다. 잘못되면 기존 스케줄을 유지한다.
+        // 취소/재등록 전에 새 cron·zone을 검증하고, 유효한 값만 캡처한다.
         CronTrigger checkTrigger;
         CronTrigger buyTrigger;
         try {
@@ -75,14 +75,19 @@ public class LottoScheduleExecutor {
             checkTrigger = new CronTrigger(check, zone);
             buyTrigger = new CronTrigger(buy, zone);
         } catch (RuntimeException exception) {
-            log.error("[Schedule] Invalid cron/zone - keeping previous schedule (check={}, buy={}, zone={})",
+            if (failFastOnInvalid) {
+                // 초기 등록 실패: 유지할 이전 스케줄이 없으므로 fail-fast — 스케줄러가 조용히 비활성화되는 것을 막는다.
+                throw new IllegalStateException(
+                        "초기 스케줄 cron/zone 설정이 유효하지 않습니다 (check=" + check + ", buy=" + buy
+                                + ", zone=" + zoneId + ")", exception);
+            }
+            log.error("[Schedule] Invalid cron/zone on refresh - keeping previous schedule (check={}, buy={}, zone={})",
                     check, buy, zoneId, exception);
             return;
         }
 
         long currentGeneration = generation.incrementAndGet();
         cancelAll();
-        // 트리거에 '검증된' CronTrigger 인스턴스를 캡처해 넘긴다 — 이후 live 프로퍼티(무효일 수 있음)를 다시 읽지 않는다.
         scheduledTasks.add(taskScheduler.schedule(this::checkLottoResults,
                 generationAwareTrigger(currentGeneration, checkTrigger)));
         scheduledTasks.add(taskScheduler.schedule(this::buyLottoTickets,
@@ -109,7 +114,6 @@ public class LottoScheduleExecutor {
     private Trigger generationAwareTrigger(long ownedGeneration, CronTrigger cronTrigger) {
         return (TriggerContext triggerContext) -> {
             if (ownedGeneration != generation.get()) {
-                // refresh로 대체된(오래된) 트리거 — 재예약을 중단해 중복 발화를 막는다.
                 return null;
             }
             return cronTrigger.nextExecution(triggerContext);

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/LottoAutomationPlaywrightAdapter.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/LottoAutomationPlaywrightAdapter.java
@@ -1,6 +1,8 @@
 package org.nowstart.lotto.adapter.out.browser;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import lombok.RequiredArgsConstructor;
 import org.nowstart.lotto.application.port.out.LottoAutomationPort;
 import org.nowstart.lotto.application.port.out.LottoAutomationSession;
@@ -28,8 +30,8 @@ public class LottoAutomationPlaywrightAdapter implements LottoAutomationPort {
     }
 
     @Override
-    public PurchaseReceipt buy(LottoAutomationSession session, LottoUser user) {
-        return playwrightPurchaseExecutor.buy(playwrightSessionManager.requirePage(session), user);
+    public Optional<PurchaseReceipt> buy(LottoAutomationSession session, LottoUser user, BooleanSupplier abortRequested) {
+        return playwrightPurchaseExecutor.buy(playwrightSessionManager.requirePage(session), user, abortRequested);
     }
 
     @Override

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/LottoPurchaseResultSelector.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/LottoPurchaseResultSelector.java
@@ -9,10 +9,12 @@ import java.util.List;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationPort.PurchaseReceipt;
 import org.nowstart.lotto.application.port.out.LottoAutomationPort.LottoResult;
 import org.nowstart.lotto.domain.type.MessageType;
 
+@Slf4j
 final class LottoPurchaseResultSelector {
 
     private static final DateTimeFormatter PURCHASE_DATE_FORMATTER = DateTimeFormatter.BASIC_ISO_DATE;
@@ -25,10 +27,20 @@ final class LottoPurchaseResultSelector {
             List<LottoResult> results,
             PurchaseReceipt purchaseReceipt
     ) {
-        return results.stream()
+        List<LottoResult> candidates = results.stream()
                 .filter(result -> matchesPurchasedCount(result, purchaseReceipt))
                 .filter(result -> matchesPurchaseDate(result, purchaseReceipt))
                 .filter(LottoPurchaseResultSelector::isPendingPurchase)
+                .toList();
+
+        if (candidates.size() > 1) {
+            // 같은 날·같은 수량의 미추첨 후보가 여러 건이면 원장만으로는 방금 산 건을 특정하기 어렵다.
+            // 현재는 최신 회차를 선택하되, 모호성을 관측 가능하도록 경고를 남긴다.
+            log.warn("구매 결과 후보가 {}건 매칭됨 - 최신 회차를 선택합니다. count={} purchaseDate={}",
+                    candidates.size(), purchaseReceipt.count(), purchaseReceipt.purchaseDate());
+        }
+
+        return candidates.stream()
                 .max(Comparator.comparingInt(LottoPurchaseResultSelector::roundNumber));
     }
 

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightLoginExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightLoginExecutor.java
@@ -2,8 +2,10 @@ package org.nowstart.lotto.adapter.out.browser;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.options.AriaRole;
 import com.microsoft.playwright.options.LoadState;
+import com.microsoft.playwright.options.WaitForSelectorState;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationPort.LottoAccountSnapshot;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
@@ -15,7 +17,7 @@ import org.springframework.stereotype.Component;
 public class PlaywrightLoginExecutor {
 
     @Retryable(
-            includes = Exception.class,
+            includes = PlaywrightException.class,
             maxRetriesString = "${lotto.max-retries:3}",
             delayString = "${lotto.retry-delay-ms:2000}"
     )
@@ -24,6 +26,7 @@ public class PlaywrightLoginExecutor {
         page.navigate(LottoBrowserConstants.URL_LOGIN);
 
         Locator idInput = page.getByPlaceholder(LottoBrowserConstants.ID_INPUT);
+        waitForLoginFormOrSkip(idInput);
         if (idInput.isVisible()) {
             idInput.fill(user.id());
             page.getByPlaceholder(LottoBrowserConstants.PASSWORD_INPUT).fill(user.password());
@@ -48,5 +51,16 @@ public class PlaywrightLoginExecutor {
 
         log.info("[Login][{}] Success deposit={}", user.id(), snapshot.deposit());
         return snapshot;
+    }
+
+    private void waitForLoginFormOrSkip(Locator idInput) {
+        try {
+            idInput.waitFor(new Locator.WaitForOptions()
+                    .setState(WaitForSelectorState.VISIBLE)
+                    .setTimeout(5_000));
+        } catch (PlaywrightException exception) {
+            // 로그인 폼이 렌더링되지 않으면(이미 로그인 상태 등) 채우기 단계를 건너뛴다.
+            log.debug("로그인 폼이 노출되지 않아 입력을 건너뜁니다", exception);
+        }
     }
 }

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
@@ -26,11 +26,11 @@ public class PlaywrightPurchaseExecutor {
     /**
      * 주의: 구매는 멱등하지 않으므로 절대 @Retryable을 적용하지 않는다.
      * - 최종 확정 클릭 '직전'까지만 abort를 확인한다(확정 전 중단 시 Optional.empty()).
-     * - 클릭이 실제 '제출'됐는지는 확정 다이얼로그가 닫혔는지로 판정한다(이 사이트는 확정 성공 시 다이얼로그가 닫힘).
-     *   · 닫힘 = 제출됨 → 영수증 반환(호출자가 구매 후 원장 확인으로 최종 검증). 클릭이 응답 지연 등으로 예외를
-     *     던졌더라도 다이얼로그가 닫혔다면 제출된 것으로 본다.
-     *   · 여전히 열림 = actionability 실패 등으로 미제출 → 영수증을 만들지 않는다(안 산 구매가 원장의 옛 행에
-     *     오매칭되어 성공 통지되는 것을 방지).
+     * - 클릭이 정상 반환하면 확정 클릭이 '디스패치'된 것으로 보고, 다이얼로그 닫힘 지연과 무관하게 반드시 영수증을
+     *   반환한다(호출자가 구매 후 원장 확인으로 최종 검증) — 실제 구매를 미검증/미통지로 놓치지 않기 위함.
+     * - 클릭이 예외로 끝난 경우에만 '확정 다이얼로그 닫힘' 휴리스틱으로 제출 여부를 판정한다. 닫혔으면 제출된 것으로
+     *   보고 영수증을 반환하고, 여전히 열려 있으면 actionability 실패 등 미제출로 판단해 영수증을 만들지 않는다
+     *   (안 산 구매가 원장의 옛 미추첨 행에 오매칭되어 성공 통지되는 것을 방지).
      */
     public Optional<PurchaseReceipt> buy(Page page, LottoUser user, BooleanSupplier abortRequested) {
         log.info("[Purchase][{}] Start count={}", user.id(), user.count());
@@ -56,22 +56,25 @@ public class PlaywrightPurchaseExecutor {
             return Optional.empty();
         }
 
-        // 3) 짧은 타임아웃으로 클릭 시도. 예외가 나도 실제 제출 여부는 다이얼로그 상태로 판정한다.
+        // 3) 짧은 타임아웃으로 클릭 시도. 정상 반환하면 클릭이 디스패치된 것으로 본다.
+        boolean clickDispatched = false;
         try {
             finalConfirmButton.click(new Locator.ClickOptions().setTimeout(FINAL_CONFIRM_CLICK_TIMEOUT_MS));
+            clickDispatched = true;
         } catch (PlaywrightException clickException) {
             log.warn("[Purchase][{}] Final confirm click threw (actionability/응답 지연 등) - "
                     + "다이얼로그 상태로 제출 여부 판정", user.id(), clickException);
         }
 
-        // 4) 확정 다이얼로그가 닫혔으면 제출된 것 → 영수증(원장 검증). 여전히 열려 있으면 미제출 → 영수증 없음.
-        if (!confirmDialogClosed(finalConfirmButton)) {
-            log.warn("[Purchase][{}] Final confirm dialog still open - 확정 미제출로 판단, 구매 미수행", user.id());
-            return Optional.empty();
+        // 4) 클릭이 정상 디스패치됐으면 다이얼로그 닫힘 지연과 무관하게 원장 검증(단락 평가로 불필요한 대기 회피).
+        //    예외로 끝났으면 다이얼로그 닫힘 여부로 제출 판정: 닫힘=제출→검증, 열림=미제출→영수증 없음.
+        if (clickDispatched || confirmDialogClosed(finalConfirmButton)) {
+            log.info("[Purchase][{}] Confirmation submitted - proceeding to ledger verification", user.id());
+            return Optional.of(new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE)));
         }
 
-        log.info("[Purchase][{}] Confirmation submitted (dialog closed) - proceeding to ledger verification", user.id());
-        return Optional.of(new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE)));
+        log.warn("[Purchase][{}] Final confirm click failed pre-dispatch and dialog still open - 구매 미수행", user.id());
+        return Optional.empty();
     }
 
     private boolean confirmDialogClosed(Locator finalConfirmButton) {

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
@@ -1,5 +1,6 @@
 package org.nowstart.lotto.adapter.out.browser;
 
+import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.WaitForSelectorState;
@@ -8,7 +9,6 @@ import java.time.ZoneId;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationPort.PurchaseReceipt;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
-import org.springframework.resilience.annotation.Retryable;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -17,11 +17,11 @@ public class PlaywrightPurchaseExecutor {
 
     private static final ZoneId LOTTO_ZONE = ZoneId.of("Asia/Seoul");
 
-    @Retryable(
-            includes = Exception.class,
-            maxRetriesString = "${lotto.max-retries:3}",
-            delayString = "${lotto.retry-delay-ms:2000}"
-    )
+    /**
+     * 주의: 구매는 멱등하지 않으므로 절대 @Retryable을 적용하지 않는다.
+     * 최종 확정 클릭 이후에 예외가 발생하면 재시도가 중복 구매(실거래)를 유발할 수 있다.
+     * 일시적 오류는 구매 후 원장 확인(PlaywrightResultExecutor.check)에서 검증한다.
+     */
     public PurchaseReceipt buy(Page page, LottoUser user) {
         log.info("[Purchase][{}] Start count={}", user.id(), user.count());
 
@@ -32,7 +32,7 @@ public class PlaywrightPurchaseExecutor {
         page.locator(LottoBrowserConstants.QUANTITY_BOX).selectOption(String.valueOf(user.count()));
         page.locator(LottoBrowserConstants.CONFIRM_BTN).click();
         page.locator(LottoBrowserConstants.PURCHASE_BTN).click();
-        var finalConfirmButton = page.locator(LottoBrowserConstants.FINAL_CONFIRM_BTN);
+        Locator finalConfirmButton = page.locator(LottoBrowserConstants.FINAL_CONFIRM_BTN);
         finalConfirmButton.click();
         waitForFinalConfirmDialogToClose(finalConfirmButton, user);
 
@@ -40,9 +40,9 @@ public class PlaywrightPurchaseExecutor {
         return new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE));
     }
 
-    private void waitForFinalConfirmDialogToClose(com.microsoft.playwright.Locator finalConfirmButton, LottoUser user) {
+    private void waitForFinalConfirmDialogToClose(Locator finalConfirmButton, LottoUser user) {
         try {
-            finalConfirmButton.waitFor(new com.microsoft.playwright.Locator.WaitForOptions()
+            finalConfirmButton.waitFor(new Locator.WaitForOptions()
                     .setState(WaitForSelectorState.HIDDEN)
                     .setTimeout(10_000));
         } catch (Exception exception) {

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
@@ -18,11 +18,16 @@ import org.springframework.stereotype.Component;
 public class PlaywrightPurchaseExecutor {
 
     private static final ZoneId LOTTO_ZONE = ZoneId.of("Asia/Seoul");
+    // 확정 버튼이 뜰 때까지의 대기(이 구간에서 타임아웃 나도 아직 클릭하지 않는다).
+    private static final double FINAL_CONFIRM_VISIBLE_TIMEOUT_MS = 30_000;
+    // 이미 actionable해진 버튼을 즉시 누르기 위한 짧은 클릭 타임아웃(긴 actionability 대기 창 제거).
+    private static final double FINAL_CONFIRM_CLICK_TIMEOUT_MS = 3_000;
 
     /**
      * 주의: 구매는 멱등하지 않으므로 절대 @Retryable을 적용하지 않는다.
      * 최종 확정(실결제) 클릭 직전에 abortRequested를 확인해, 호출자 타임아웃으로 중단 신호가 온 경우
-     * 확정하지 않고 Optional.empty()를 반환한다(중복/뒤늦은 실구매 방지).
+     * 확정하지 않고 Optional.empty()를 반환한다. click() 자체의 actionability 대기 중 결제되는 것을 막기 위해
+     * "버튼 대기 → abort 재확인 → 짧은 타임아웃으로 즉시 클릭" 순서로 클릭 창을 최소화한다.
      */
     public Optional<PurchaseReceipt> buy(Page page, LottoUser user, BooleanSupplier abortRequested) {
         log.info("[Purchase][{}] Start count={}", user.id(), user.count());
@@ -37,13 +42,19 @@ public class PlaywrightPurchaseExecutor {
 
         Locator finalConfirmButton = page.locator(LottoBrowserConstants.FINAL_CONFIRM_BTN);
 
-        // 실결제(최종 확정) 직전 마지막 취소 확인 — 여기까지 진행된 뒤 타임아웃된 작업이 실구매하는 것을 방지.
+        // 1) 확정 버튼이 클릭 가능해질 때까지 먼저 대기한다(아직 클릭하지 않음).
+        finalConfirmButton.waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.VISIBLE)
+                .setTimeout(FINAL_CONFIRM_VISIBLE_TIMEOUT_MS));
+
+        // 2) 대기 직후, 실결제 클릭 직전에 마지막으로 abort를 확인한다.
         if (abortRequested.getAsBoolean()) {
             log.warn("[Purchase][{}] Aborted before final confirmation (호출자 타임아웃) - 구매 미수행", user.id());
             return Optional.empty();
         }
 
-        finalConfirmButton.click();
+        // 3) 이미 actionable하므로 짧은 타임아웃으로 즉시 클릭한다(긴 대기 창을 없애 타임아웃 후 실결제 방지).
+        finalConfirmButton.click(new Locator.ClickOptions().setTimeout(FINAL_CONFIRM_CLICK_TIMEOUT_MS));
         waitForFinalConfirmDialogToClose(finalConfirmButton, user);
 
         log.info("[Purchase][{}] Success", user.id());

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
@@ -2,6 +2,7 @@ package org.nowstart.lotto.adapter.out.browser;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import java.time.LocalDate;
@@ -18,16 +19,14 @@ import org.springframework.stereotype.Component;
 public class PlaywrightPurchaseExecutor {
 
     private static final ZoneId LOTTO_ZONE = ZoneId.of("Asia/Seoul");
-    // 확정 버튼이 뜰 때까지의 대기(이 구간에서 타임아웃 나도 아직 클릭하지 않는다).
     private static final double FINAL_CONFIRM_VISIBLE_TIMEOUT_MS = 30_000;
-    // 이미 actionable해진 버튼을 즉시 누르기 위한 짧은 클릭 타임아웃(긴 actionability 대기 창 제거).
     private static final double FINAL_CONFIRM_CLICK_TIMEOUT_MS = 3_000;
 
     /**
      * 주의: 구매는 멱등하지 않으므로 절대 @Retryable을 적용하지 않는다.
-     * 최종 확정(실결제) 클릭 직전에 abortRequested를 확인해, 호출자 타임아웃으로 중단 신호가 온 경우
-     * 확정하지 않고 Optional.empty()를 반환한다. click() 자체의 actionability 대기 중 결제되는 것을 막기 위해
-     * "버튼 대기 → abort 재확인 → 짧은 타임아웃으로 즉시 클릭" 순서로 클릭 창을 최소화한다.
+     * - 최종 확정 클릭 '직전'까지만 abort를 확인한다(확정 전 중단 시 Optional.empty()).
+     * - 일단 클릭을 시도한 뒤에는(사이트에 요청이 전송됐을 수 있으므로) 클릭이 타임아웃/예외로 끝나더라도
+     *   실패로 단정하지 않고 영수증을 반환한다 → 호출자가 구매 후 원장 확인으로 성사 여부를 판정한다.
      */
     public Optional<PurchaseReceipt> buy(Page page, LottoUser user, BooleanSupplier abortRequested) {
         log.info("[Purchase][{}] Start count={}", user.id(), user.count());
@@ -47,28 +46,29 @@ public class PlaywrightPurchaseExecutor {
                 .setState(WaitForSelectorState.VISIBLE)
                 .setTimeout(FINAL_CONFIRM_VISIBLE_TIMEOUT_MS));
 
-        // 2) 대기 직후, 실결제 클릭 직전에 마지막으로 abort를 확인한다.
+        // 2) 대기 직후, 실결제 클릭 직전에 마지막으로 abort를 확인한다(여기까진 아직 미클릭).
         if (abortRequested.getAsBoolean()) {
             log.warn("[Purchase][{}] Aborted before final confirmation (호출자 타임아웃) - 구매 미수행", user.id());
             return Optional.empty();
         }
 
-        // 3) 이미 actionable하므로 짧은 타임아웃으로 즉시 클릭한다(긴 대기 창을 없애 타임아웃 후 실결제 방지).
-        finalConfirmButton.click(new Locator.ClickOptions().setTimeout(FINAL_CONFIRM_CLICK_TIMEOUT_MS));
-        waitForFinalConfirmDialogToClose(finalConfirmButton, user);
+        // 3) 여기서부터는 클릭이 실제 전송될 수 있다. 짧은 타임아웃으로 즉시 클릭하되,
+        //    클릭이 예외로 끝나도(응답 지연 등) 실패로 단정하지 않고 원장 확인으로 넘긴다.
+        try {
+            finalConfirmButton.click(new Locator.ClickOptions().setTimeout(FINAL_CONFIRM_CLICK_TIMEOUT_MS));
+            waitForFinalConfirmDialogToClose(finalConfirmButton, user);
+        } catch (PlaywrightException clickException) {
+            log.warn("[Purchase][{}] Final confirm click did not complete cleanly (타임아웃/오류) - "
+                    + "구매 성사 여부는 원장 확인으로 검증", user.id(), clickException);
+        }
 
-        log.info("[Purchase][{}] Success", user.id());
+        log.info("[Purchase][{}] Confirm click attempted - proceeding to ledger verification", user.id());
         return Optional.of(new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE)));
     }
 
     private void waitForFinalConfirmDialogToClose(Locator finalConfirmButton, LottoUser user) {
-        try {
-            finalConfirmButton.waitFor(new Locator.WaitForOptions()
-                    .setState(WaitForSelectorState.HIDDEN)
-                    .setTimeout(10_000));
-        } catch (Exception exception) {
-            log.warn("[Purchase][{}] Final confirm dialog did not close within timeout; "
-                    + "purchase ledger check will verify the result", user.id(), exception);
-        }
+        finalConfirmButton.waitFor(new Locator.WaitForOptions()
+                .setState(WaitForSelectorState.HIDDEN)
+                .setTimeout(10_000));
     }
 }

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
@@ -21,12 +21,16 @@ public class PlaywrightPurchaseExecutor {
     private static final ZoneId LOTTO_ZONE = ZoneId.of("Asia/Seoul");
     private static final double FINAL_CONFIRM_VISIBLE_TIMEOUT_MS = 30_000;
     private static final double FINAL_CONFIRM_CLICK_TIMEOUT_MS = 3_000;
+    private static final double FINAL_CONFIRM_HIDDEN_TIMEOUT_MS = 10_000;
 
     /**
      * 주의: 구매는 멱등하지 않으므로 절대 @Retryable을 적용하지 않는다.
      * - 최종 확정 클릭 '직전'까지만 abort를 확인한다(확정 전 중단 시 Optional.empty()).
-     * - 일단 클릭을 시도한 뒤에는(사이트에 요청이 전송됐을 수 있으므로) 클릭이 타임아웃/예외로 끝나더라도
-     *   실패로 단정하지 않고 영수증을 반환한다 → 호출자가 구매 후 원장 확인으로 성사 여부를 판정한다.
+     * - 클릭이 실제 '제출'됐는지는 확정 다이얼로그가 닫혔는지로 판정한다(이 사이트는 확정 성공 시 다이얼로그가 닫힘).
+     *   · 닫힘 = 제출됨 → 영수증 반환(호출자가 구매 후 원장 확인으로 최종 검증). 클릭이 응답 지연 등으로 예외를
+     *     던졌더라도 다이얼로그가 닫혔다면 제출된 것으로 본다.
+     *   · 여전히 열림 = actionability 실패 등으로 미제출 → 영수증을 만들지 않는다(안 산 구매가 원장의 옛 행에
+     *     오매칭되어 성공 통지되는 것을 방지).
      */
     public Optional<PurchaseReceipt> buy(Page page, LottoUser user, BooleanSupplier abortRequested) {
         log.info("[Purchase][{}] Start count={}", user.id(), user.count());
@@ -41,34 +45,43 @@ public class PlaywrightPurchaseExecutor {
 
         Locator finalConfirmButton = page.locator(LottoBrowserConstants.FINAL_CONFIRM_BTN);
 
-        // 1) 확정 버튼이 클릭 가능해질 때까지 먼저 대기한다(아직 클릭하지 않음).
+        // 1) 확정 버튼이 뜰 때까지 먼저 대기(아직 클릭하지 않음).
         finalConfirmButton.waitFor(new Locator.WaitForOptions()
                 .setState(WaitForSelectorState.VISIBLE)
                 .setTimeout(FINAL_CONFIRM_VISIBLE_TIMEOUT_MS));
 
-        // 2) 대기 직후, 실결제 클릭 직전에 마지막으로 abort를 확인한다(여기까진 아직 미클릭).
+        // 2) 실결제 클릭 직전에 마지막으로 abort 확인(여기까진 미클릭 확실).
         if (abortRequested.getAsBoolean()) {
             log.warn("[Purchase][{}] Aborted before final confirmation (호출자 타임아웃) - 구매 미수행", user.id());
             return Optional.empty();
         }
 
-        // 3) 여기서부터는 클릭이 실제 전송될 수 있다. 짧은 타임아웃으로 즉시 클릭하되,
-        //    클릭이 예외로 끝나도(응답 지연 등) 실패로 단정하지 않고 원장 확인으로 넘긴다.
+        // 3) 짧은 타임아웃으로 클릭 시도. 예외가 나도 실제 제출 여부는 다이얼로그 상태로 판정한다.
         try {
             finalConfirmButton.click(new Locator.ClickOptions().setTimeout(FINAL_CONFIRM_CLICK_TIMEOUT_MS));
-            waitForFinalConfirmDialogToClose(finalConfirmButton, user);
         } catch (PlaywrightException clickException) {
-            log.warn("[Purchase][{}] Final confirm click did not complete cleanly (타임아웃/오류) - "
-                    + "구매 성사 여부는 원장 확인으로 검증", user.id(), clickException);
+            log.warn("[Purchase][{}] Final confirm click threw (actionability/응답 지연 등) - "
+                    + "다이얼로그 상태로 제출 여부 판정", user.id(), clickException);
         }
 
-        log.info("[Purchase][{}] Confirm click attempted - proceeding to ledger verification", user.id());
+        // 4) 확정 다이얼로그가 닫혔으면 제출된 것 → 영수증(원장 검증). 여전히 열려 있으면 미제출 → 영수증 없음.
+        if (!confirmDialogClosed(finalConfirmButton)) {
+            log.warn("[Purchase][{}] Final confirm dialog still open - 확정 미제출로 판단, 구매 미수행", user.id());
+            return Optional.empty();
+        }
+
+        log.info("[Purchase][{}] Confirmation submitted (dialog closed) - proceeding to ledger verification", user.id());
         return Optional.of(new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE)));
     }
 
-    private void waitForFinalConfirmDialogToClose(Locator finalConfirmButton, LottoUser user) {
-        finalConfirmButton.waitFor(new Locator.WaitForOptions()
-                .setState(WaitForSelectorState.HIDDEN)
-                .setTimeout(10_000));
+    private boolean confirmDialogClosed(Locator finalConfirmButton) {
+        try {
+            finalConfirmButton.waitFor(new Locator.WaitForOptions()
+                    .setState(WaitForSelectorState.HIDDEN)
+                    .setTimeout(FINAL_CONFIRM_HIDDEN_TIMEOUT_MS));
+            return true;
+        } catch (PlaywrightException exception) {
+            return false;
+        }
     }
 }

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutor.java
@@ -6,6 +6,8 @@ import com.microsoft.playwright.options.LoadState;
 import com.microsoft.playwright.options.WaitForSelectorState;
 import java.time.LocalDate;
 import java.time.ZoneId;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationPort.PurchaseReceipt;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
@@ -19,10 +21,10 @@ public class PlaywrightPurchaseExecutor {
 
     /**
      * 주의: 구매는 멱등하지 않으므로 절대 @Retryable을 적용하지 않는다.
-     * 최종 확정 클릭 이후에 예외가 발생하면 재시도가 중복 구매(실거래)를 유발할 수 있다.
-     * 일시적 오류는 구매 후 원장 확인(PlaywrightResultExecutor.check)에서 검증한다.
+     * 최종 확정(실결제) 클릭 직전에 abortRequested를 확인해, 호출자 타임아웃으로 중단 신호가 온 경우
+     * 확정하지 않고 Optional.empty()를 반환한다(중복/뒤늦은 실구매 방지).
      */
-    public PurchaseReceipt buy(Page page, LottoUser user) {
+    public Optional<PurchaseReceipt> buy(Page page, LottoUser user, BooleanSupplier abortRequested) {
         log.info("[Purchase][{}] Start count={}", user.id(), user.count());
 
         page.navigate(LottoBrowserConstants.URL_PURCHASE);
@@ -32,12 +34,20 @@ public class PlaywrightPurchaseExecutor {
         page.locator(LottoBrowserConstants.QUANTITY_BOX).selectOption(String.valueOf(user.count()));
         page.locator(LottoBrowserConstants.CONFIRM_BTN).click();
         page.locator(LottoBrowserConstants.PURCHASE_BTN).click();
+
         Locator finalConfirmButton = page.locator(LottoBrowserConstants.FINAL_CONFIRM_BTN);
+
+        // 실결제(최종 확정) 직전 마지막 취소 확인 — 여기까지 진행된 뒤 타임아웃된 작업이 실구매하는 것을 방지.
+        if (abortRequested.getAsBoolean()) {
+            log.warn("[Purchase][{}] Aborted before final confirmation (호출자 타임아웃) - 구매 미수행", user.id());
+            return Optional.empty();
+        }
+
         finalConfirmButton.click();
         waitForFinalConfirmDialogToClose(finalConfirmButton, user);
 
         log.info("[Purchase][{}] Success", user.id());
-        return new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE));
+        return Optional.of(new PurchaseReceipt(user.count(), LocalDate.now(LOTTO_ZONE)));
     }
 
     private void waitForFinalConfirmDialogToClose(Locator finalConfirmButton, LottoUser user) {

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightResultExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightResultExecutor.java
@@ -95,8 +95,11 @@ public class PlaywrightResultExecutor {
             attempt++;
         } while (System.currentTimeMillis() < deadlineMs);
 
-        throw new IllegalStateException("Fresh purchase result was not found in lotto ledger within "
-                + lottoProperties.getPurchaseResultTimeoutMs() + "ms");
+        // 구매는 이미 성공했는데 원장 행이 timeout 직후 노출될 수 있다. 이 check 재시도는 재구매를 유발하지 않으므로
+        // 재시도 가능한 PlaywrightException으로 던져 @Retryable(PlaywrightException) 정책이 한 번 더 폴링하도록 한다.
+        throw new com.microsoft.playwright.PlaywrightException(
+                "Fresh purchase result was not found in lotto ledger within "
+                        + lottoProperties.getPurchaseResultTimeoutMs() + "ms");
     }
 
     private Optional<ResultRow> selectNewPurchaseRow(

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightResultExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightResultExecutor.java
@@ -37,21 +37,25 @@ public class PlaywrightResultExecutor {
         List<ResultRow> resultRows = loadResultRows(page);
         List<CheckResult> results = new ArrayList<>();
         int captureFailures = 0;
+        Exception lastCaptureFailure = null;
         for (ResultRow resultRow : resultRows) {
             try {
                 results.add(captureDetail(page, resultRow));
             } catch (Exception exception) {
                 captureFailures++;
+                lastCaptureFailure = exception;
                 log.warn("[Check] Skip detail capture resultKey={}",
                         LottoPurchaseResultSelector.key(resultRow.result()), exception);
             }
         }
 
-        // 파싱 가능한 행이 있는데 상세 캡처가 전부 실패한 경우는 selector 변경 등 이상 신호이므로
-        // 빈 결과를 "성공(할 일 없음)"으로 오인하지 않도록 실패로 처리한다.
+        // 파싱 가능한 행이 있는데 상세 캡처가 전부 실패한 경우는 이상 신호이므로 실패로 처리한다.
+        // 단, 일시적 오류(모달 대기/스크린샷 타임아웃 등)일 수 있으므로 재시도 대상인 PlaywrightException으로 던져
+        // 설정된 재시도 정책을 우회하지 않도록 한다(원인 보존).
         if (!resultRows.isEmpty() && results.isEmpty()) {
-            throw new IllegalStateException(
-                    "결과 " + resultRows.size() + "행의 상세 캡처가 모두 실패했습니다 (selector 변경 의심)");
+            throw new PlaywrightException(
+                    "결과 " + resultRows.size() + "행의 상세 캡처가 모두 실패했습니다 (selector 변경/일시 오류 의심)",
+                    lastCaptureFailure);
         }
 
         log.info("[Check] Complete resultCount={} captureFailures={}", results.size(), captureFailures);

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightResultExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightResultExecutor.java
@@ -2,6 +2,7 @@ package org.nowstart.lotto.adapter.out.browser;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.PlaywrightException;
 import com.microsoft.playwright.options.LoadState;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,7 +26,7 @@ public class PlaywrightResultExecutor {
     }
 
     @Retryable(
-            includes = Exception.class,
+            includes = PlaywrightException.class,
             maxRetriesString = "${lotto.max-retries:3}",
             delayString = "${lotto.retry-delay-ms:2000}"
     )
@@ -35,21 +36,30 @@ public class PlaywrightResultExecutor {
 
         List<ResultRow> resultRows = loadResultRows(page);
         List<CheckResult> results = new ArrayList<>();
+        int captureFailures = 0;
         for (ResultRow resultRow : resultRows) {
             try {
                 results.add(captureDetail(page, resultRow));
             } catch (Exception exception) {
+                captureFailures++;
                 log.warn("[Check] Skip detail capture resultKey={}",
                         LottoPurchaseResultSelector.key(resultRow.result()), exception);
             }
         }
 
-        log.info("[Check] Complete resultCount={}", results.size());
+        // 파싱 가능한 행이 있는데 상세 캡처가 전부 실패한 경우는 selector 변경 등 이상 신호이므로
+        // 빈 결과를 "성공(할 일 없음)"으로 오인하지 않도록 실패로 처리한다.
+        if (!resultRows.isEmpty() && results.isEmpty()) {
+            throw new IllegalStateException(
+                    "결과 " + resultRows.size() + "행의 상세 캡처가 모두 실패했습니다 (selector 변경 의심)");
+        }
+
+        log.info("[Check] Complete resultCount={} captureFailures={}", results.size(), captureFailures);
         return results;
     }
 
     @Retryable(
-            includes = Exception.class,
+            includes = PlaywrightException.class,
             maxRetriesString = "${lotto.max-retries:3}",
             delayString = "${lotto.retry-delay-ms:2000}"
     )

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
@@ -46,6 +46,7 @@ public class PlaywrightSessionManager {
         Playwright playwright = null;
         Browser browser = null;
         BrowserContext context = null;
+        boolean traceStarted = false;
         try {
             playwright = Playwright.create();
             browser = playwright.chromium().launch(browserLaunchOptions.get());
@@ -54,19 +55,21 @@ public class PlaywrightSessionManager {
                     .setIsMobile(false));
             context.addInitScript(LottoBrowserConstants.SCRIPT_CHROME_PLATFORM);
             playWrightTraceArchive.start(context);
+            traceStarted = true;
             return new PlaywrightLottoSession(
                     context.newPage(),
                     context,
                     browser,
                     playwright,
                     playWrightTraceArchive,
+                    new AtomicBoolean(false),
                     releasePermit
             );
         } catch (RuntimeException exception) {
-            cleanupFailedOpen(context, browser, playwright, releasePermit);
+            cleanupFailedOpen(context, browser, playwright, releasePermit, traceStarted);
             throw exception;
         } catch (Error error) {
-            cleanupFailedOpen(context, browser, playwright, releasePermit);
+            cleanupFailedOpen(context, browser, playwright, releasePermit, traceStarted);
             throw error;
         }
     }
@@ -99,8 +102,12 @@ public class PlaywrightSessionManager {
             BrowserContext context,
             Browser browser,
             Playwright playwright,
-            Runnable releasePermit
+            Runnable releasePermit,
+            boolean traceStarted
     ) {
+        if (traceStarted && context != null) {
+            playWrightTraceArchive.stop(context, true);
+        }
         closeQuietly(context, "브라우저 컨텍스트 종료 실패");
         closeQuietly(browser, "브라우저 종료 실패");
         closeQuietly(playwright, "Playwright 종료 실패");
@@ -113,13 +120,19 @@ public class PlaywrightSessionManager {
             Browser browser,
             Playwright playwright,
             PlaywrightTraceArchive playWrightTraceArchive,
+            AtomicBoolean failed,
             Runnable releasePermit
     ) implements LottoAutomationSession {
 
         @Override
+        public void markFailed() {
+            failed.set(true);
+        }
+
+        @Override
         public void close() {
             try {
-                playWrightTraceArchive.stop(context);
+                playWrightTraceArchive.stop(context, failed.get());
             } finally {
                 try {
                     closePage();

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
@@ -12,8 +12,6 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationSession;
 import org.nowstart.lotto.config.LottoProperties;
-import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -23,7 +21,7 @@ public class PlaywrightSessionManager {
     private final Supplier<BrowserType.LaunchOptions> browserLaunchOptions;
     private final PlaywrightTraceArchive playWrightTraceArchive;
     private final LottoProperties lottoProperties;
-    private final ResizableSemaphore sessionLimiter;
+    private final Semaphore sessionLimiter;
 
     public PlaywrightSessionManager(
             Supplier<BrowserType.LaunchOptions> browserLaunchOptions,
@@ -33,14 +31,7 @@ public class PlaywrightSessionManager {
         this.browserLaunchOptions = browserLaunchOptions;
         this.playWrightTraceArchive = playWrightTraceArchive;
         this.lottoProperties = lottoProperties;
-        this.sessionLimiter = new ResizableSemaphore(lottoProperties.getMaxConcurrentSessions());
-    }
-
-    @EventListener(RefreshScopeRefreshedEvent.class)
-    public void onRefresh(RefreshScopeRefreshedEvent event) {
-        int newLimit = lottoProperties.getMaxConcurrentSessions();
-        sessionLimiter.resize(newLimit);
-        log.info("[Session] max-concurrent-sessions resized to {}", newLimit);
+        this.sessionLimiter = new Semaphore(lottoProperties.getMaxConcurrentSessions(), true);
     }
 
     public LottoAutomationSession openSession() {
@@ -114,31 +105,6 @@ public class PlaywrightSessionManager {
         closeQuietly(browser, "브라우저 종료 실패");
         closeQuietly(playwright, "Playwright 종료 실패");
         releasePermit.run();
-    }
-
-    /** 런타임에 permit 수를 조정할 수 있는 세마포어. */
-    private static final class ResizableSemaphore extends Semaphore {
-
-        private int currentPermits;
-
-        ResizableSemaphore(int permits) {
-            super(permits, true);
-            this.currentPermits = permits;
-        }
-
-        synchronized void resize(int newPermits) {
-            if (newPermits < 1) {
-                log.warn("[Session] 무시된 잘못된 max-concurrent-sessions 값: {}", newPermits);
-                return;
-            }
-            int delta = newPermits - currentPermits;
-            if (delta > 0) {
-                release(delta);
-            } else if (delta < 0) {
-                reducePermits(-delta);
-            }
-            currentPermits = newPermits;
-        }
     }
 
     private record PlaywrightLottoSession(

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
@@ -6,6 +6,7 @@ import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
@@ -35,10 +36,6 @@ public class PlaywrightSessionManager {
         this.sessionLimiter = new ResizableSemaphore(lottoProperties.getMaxConcurrentSessions());
     }
 
-    /**
-     * /actuator/refresh 로 lotto.max-concurrent-sessions 가 바뀌면 세마포어 permit 수를 재조정한다.
-     * (LottoProperties 는 refresh 시 재바인딩되므로 현재 값을 읽어 반영)
-     */
     @EventListener(RefreshScopeRefreshedEvent.class)
     public void onRefresh(RefreshScopeRefreshedEvent event) {
         int newLimit = lottoProperties.getMaxConcurrentSessions();
@@ -78,7 +75,6 @@ public class PlaywrightSessionManager {
             cleanupFailedOpen(context, browser, playwright, releasePermit);
             throw exception;
         } catch (Error error) {
-            // 치명적 오류(브라우저 launch 실패 등)에도 permit을 반드시 반납해야 세마포어가 영구 고갈되지 않는다.
             cleanupFailedOpen(context, browser, playwright, releasePermit);
             throw error;
         }
@@ -91,9 +87,17 @@ public class PlaywrightSessionManager {
         throw new IllegalArgumentException("Unsupported session type: " + session.getClass().getName());
     }
 
+    /**
+     * 세마포어 대기를 무한정 하지 않고 작업 타임아웃 내로 제한한다. 모든 permit이 hung 세션에 잡혀 있어
+     * 확보하지 못하면 예외로 종료해, future가 반드시 완료되고 in-flight 키가 해제되도록 한다(영구 skip 방지).
+     */
     private void acquirePermit() {
+        long timeoutMs = lottoProperties.getUserTaskTimeoutMs();
         try {
-            sessionLimiter.acquire();
+            if (!sessionLimiter.tryAcquire(timeoutMs, TimeUnit.MILLISECONDS)) {
+                throw new IllegalStateException(
+                        "브라우저 세션 허가를 " + timeoutMs + "ms 내에 확보하지 못했습니다 (동시 세션 한도 초과/지연)");
+            }
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("브라우저 세션 허가 획득 중 인터럽트되었습니다", exception);

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
@@ -59,12 +59,13 @@ public class PlaywrightSessionManager {
                     playWrightTraceArchive,
                     releasePermit
             );
-        } catch (Exception exception) {
-            closeQuietly(context, "브라우저 컨텍스트 종료 실패");
-            closeQuietly(browser, "브라우저 종료 실패");
-            closeQuietly(playwright, "Playwright 종료 실패");
-            releasePermit.run();
+        } catch (RuntimeException exception) {
+            cleanupFailedOpen(context, browser, playwright, releasePermit);
             throw exception;
+        } catch (Error error) {
+            // 치명적 오류(브라우저 launch 실패 등)에도 permit을 반드시 반납해야 세마포어가 영구 고갈되지 않는다.
+            cleanupFailedOpen(context, browser, playwright, releasePermit);
+            throw error;
         }
     }
 
@@ -82,6 +83,18 @@ public class PlaywrightSessionManager {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("브라우저 세션 허가 획득 중 인터럽트되었습니다", exception);
         }
+    }
+
+    private void cleanupFailedOpen(
+            BrowserContext context,
+            Browser browser,
+            Playwright playwright,
+            Runnable releasePermit
+    ) {
+        closeQuietly(context, "브라우저 컨텍스트 종료 실패");
+        closeQuietly(browser, "브라우저 종료 실패");
+        closeQuietly(playwright, "Playwright 종료 실패");
+        releasePermit.run();
     }
 
     private record PlaywrightLottoSession(

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
@@ -5,25 +5,46 @@ import com.microsoft.playwright.BrowserContext;
 import com.microsoft.playwright.BrowserType;
 import com.microsoft.playwright.Page;
 import com.microsoft.playwright.Playwright;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationSession;
+import org.nowstart.lotto.config.LottoProperties;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PlaywrightSessionManager {
 
     private final Supplier<BrowserType.LaunchOptions> browserLaunchOptions;
     private final PlaywrightTraceArchive playWrightTraceArchive;
+    private final Semaphore sessionLimiter;
+
+    public PlaywrightSessionManager(
+            Supplier<BrowserType.LaunchOptions> browserLaunchOptions,
+            PlaywrightTraceArchive playWrightTraceArchive,
+            LottoProperties lottoProperties
+    ) {
+        this.browserLaunchOptions = browserLaunchOptions;
+        this.playWrightTraceArchive = playWrightTraceArchive;
+        this.sessionLimiter = new Semaphore(lottoProperties.getMaxConcurrentSessions(), true);
+    }
 
     public LottoAutomationSession openSession() {
-        Playwright playwright = Playwright.create();
+        acquirePermit();
+        AtomicBoolean permitReleased = new AtomicBoolean(false);
+        Runnable releasePermit = () -> {
+            if (permitReleased.compareAndSet(false, true)) {
+                sessionLimiter.release();
+            }
+        };
+
+        Playwright playwright = null;
         Browser browser = null;
         BrowserContext context = null;
         try {
+            playwright = Playwright.create();
             browser = playwright.chromium().launch(browserLaunchOptions.get());
             context = browser.newContext(new Browser.NewContextOptions()
                     .setUserAgent(LottoBrowserConstants.USER_AGENT_CHROME)
@@ -35,12 +56,14 @@ public class PlaywrightSessionManager {
                     context,
                     browser,
                     playwright,
-                    playWrightTraceArchive
+                    playWrightTraceArchive,
+                    releasePermit
             );
         } catch (Exception exception) {
             closeQuietly(context, "브라우저 컨텍스트 종료 실패");
             closeQuietly(browser, "브라우저 종료 실패");
             closeQuietly(playwright, "Playwright 종료 실패");
+            releasePermit.run();
             throw exception;
         }
     }
@@ -52,12 +75,22 @@ public class PlaywrightSessionManager {
         throw new IllegalArgumentException("Unsupported session type: " + session.getClass().getName());
     }
 
+    private void acquirePermit() {
+        try {
+            sessionLimiter.acquire();
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("브라우저 세션 허가 획득 중 인터럽트되었습니다", exception);
+        }
+    }
+
     private record PlaywrightLottoSession(
             Page page,
             BrowserContext context,
             Browser browser,
             Playwright playwright,
-            PlaywrightTraceArchive playWrightTraceArchive
+            PlaywrightTraceArchive playWrightTraceArchive,
+            Runnable releasePermit
     ) implements LottoAutomationSession {
 
         @Override
@@ -65,10 +98,14 @@ public class PlaywrightSessionManager {
             try {
                 playWrightTraceArchive.stop(context);
             } finally {
-                closePage();
-                closeQuietly(context, "브라우저 컨텍스트 종료 실패");
-                closeQuietly(browser, "브라우저 종료 실패");
-                closeQuietly(playwright, "Playwright 종료 실패");
+                try {
+                    closePage();
+                    closeQuietly(context, "브라우저 컨텍스트 종료 실패");
+                    closeQuietly(browser, "브라우저 종료 실패");
+                    closeQuietly(playwright, "Playwright 종료 실패");
+                } finally {
+                    releasePermit.run();
+                }
             }
         }
 

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightSessionManager.java
@@ -11,6 +11,8 @@ import java.util.function.Supplier;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LottoAutomationSession;
 import org.nowstart.lotto.config.LottoProperties;
+import org.springframework.cloud.context.scope.refresh.RefreshScopeRefreshedEvent;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -19,7 +21,8 @@ public class PlaywrightSessionManager {
 
     private final Supplier<BrowserType.LaunchOptions> browserLaunchOptions;
     private final PlaywrightTraceArchive playWrightTraceArchive;
-    private final Semaphore sessionLimiter;
+    private final LottoProperties lottoProperties;
+    private final ResizableSemaphore sessionLimiter;
 
     public PlaywrightSessionManager(
             Supplier<BrowserType.LaunchOptions> browserLaunchOptions,
@@ -28,7 +31,19 @@ public class PlaywrightSessionManager {
     ) {
         this.browserLaunchOptions = browserLaunchOptions;
         this.playWrightTraceArchive = playWrightTraceArchive;
-        this.sessionLimiter = new Semaphore(lottoProperties.getMaxConcurrentSessions(), true);
+        this.lottoProperties = lottoProperties;
+        this.sessionLimiter = new ResizableSemaphore(lottoProperties.getMaxConcurrentSessions());
+    }
+
+    /**
+     * /actuator/refresh 로 lotto.max-concurrent-sessions 가 바뀌면 세마포어 permit 수를 재조정한다.
+     * (LottoProperties 는 refresh 시 재바인딩되므로 현재 값을 읽어 반영)
+     */
+    @EventListener(RefreshScopeRefreshedEvent.class)
+    public void onRefresh(RefreshScopeRefreshedEvent event) {
+        int newLimit = lottoProperties.getMaxConcurrentSessions();
+        sessionLimiter.resize(newLimit);
+        log.info("[Session] max-concurrent-sessions resized to {}", newLimit);
     }
 
     public LottoAutomationSession openSession() {
@@ -95,6 +110,31 @@ public class PlaywrightSessionManager {
         closeQuietly(browser, "브라우저 종료 실패");
         closeQuietly(playwright, "Playwright 종료 실패");
         releasePermit.run();
+    }
+
+    /** 런타임에 permit 수를 조정할 수 있는 세마포어. */
+    private static final class ResizableSemaphore extends Semaphore {
+
+        private int currentPermits;
+
+        ResizableSemaphore(int permits) {
+            super(permits, true);
+            this.currentPermits = permits;
+        }
+
+        synchronized void resize(int newPermits) {
+            if (newPermits < 1) {
+                log.warn("[Session] 무시된 잘못된 max-concurrent-sessions 값: {}", newPermits);
+                return;
+            }
+            int delta = newPermits - currentPermits;
+            if (delta > 0) {
+                release(delta);
+            } else if (delta < 0) {
+                reducePermits(-delta);
+            }
+            currentPermits = newPermits;
+        }
     }
 
     private record PlaywrightLottoSession(

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
@@ -12,27 +12,30 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.stream.StreamSupport;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.nowstart.lotto.config.LottoProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class PlaywrightTraceArchive {
 
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
     private static final String TRACE_GLOB = "lotto-trace-*.zip";
     private final Object cleanupMonitor = new Object();
 
+    // 트레이스는 로그인 비밀번호 입력·계정/예치금 등 민감 정보를 캡처하므로, refresh로 즉시 끌 수 있도록
+    // 생성 시점 캡처(@Value) 대신 재바인딩되는 LottoProperties에서 매 호출 시 현재 값을 읽는다.
+    private final LottoProperties lottoProperties;
+
     @Value("${logging.file.path:./logs}")
     private String logPath;
 
     @Value("${logging.logback.rollingpolicy.max-history:7}")
     private int maxTraceFiles;
-
-    // 트레이스는 로그인 비밀번호 입력·계정/예치금 등 민감 정보를 캡처하므로 기본 비활성화한다.
-    @Value("${lotto.trace-enabled:false}")
-    private boolean traceEnabled;
 
     @PostConstruct
     void initialize() {
@@ -45,7 +48,7 @@ public class PlaywrightTraceArchive {
     }
 
     public void start(BrowserContext context) {
-        if (!traceEnabled) {
+        if (!isTraceEnabled()) {
             return;
         }
         context.tracing().start(new Tracing.StartOptions()
@@ -55,7 +58,7 @@ public class PlaywrightTraceArchive {
     }
 
     public void stop(BrowserContext context) {
-        if (!traceEnabled) {
+        if (!isTraceEnabled()) {
             return;
         }
         try {
@@ -67,6 +70,10 @@ public class PlaywrightTraceArchive {
         } catch (Exception exception) {
             log.warn("페이지 종료 중 오류 발생", exception);
         }
+    }
+
+    private boolean isTraceEnabled() {
+        return Boolean.TRUE.equals(lottoProperties.getTraceEnabled());
     }
 
     private void ensureLogDirectoryExists() throws IOException {

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
@@ -12,23 +12,17 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 import java.util.stream.StreamSupport;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.nowstart.lotto.config.LottoProperties;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-@RequiredArgsConstructor
 public class PlaywrightTraceArchive {
 
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
     private static final String TRACE_GLOB = "lotto-trace-*.zip";
     private final Object cleanupMonitor = new Object();
-
-    // 트레이스는 로그인 비밀번호 입력·계정/예치금 등 민감 정보를 캡처하므로 기본 비활성화한다.
-    private final LottoProperties lottoProperties;
 
     @Value("${logging.file.path:./logs}")
     private String logPath;
@@ -47,32 +41,26 @@ public class PlaywrightTraceArchive {
     }
 
     public void start(BrowserContext context) {
-        if (!isTraceEnabled()) {
-            return;
-        }
         context.tracing().start(new Tracing.StartOptions()
                 .setScreenshots(true)
                 .setSnapshots(true)
                 .setSources(true));
     }
 
-    public void stop(BrowserContext context) {
-        if (!isTraceEnabled()) {
-            return;
-        }
+    public void stop(BrowserContext context, boolean saveTrace) {
         try {
+            if (!saveTrace) {
+                context.tracing().stop();
+                return;
+            }
             String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
             String traceId = UUID.randomUUID().toString().substring(0, 8);
             Path tracePath = Paths.get(logPath, "lotto-trace-" + timestamp + "-" + traceId + ".zip");
             context.tracing().stop(new Tracing.StopOptions().setPath(tracePath));
             cleanupOldTraceFiles();
         } catch (Exception exception) {
-            log.warn("페이지 종료 중 오류 발생", exception);
+            log.warn("트레이스 종료 중 오류 발생", exception);
         }
-    }
-
-    private boolean isTraceEnabled() {
-        return Boolean.TRUE.equals(lottoProperties.getTraceEnabled());
     }
 
     private void ensureLogDirectoryExists() throws IOException {

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
@@ -27,8 +27,7 @@ public class PlaywrightTraceArchive {
     private static final String TRACE_GLOB = "lotto-trace-*.zip";
     private final Object cleanupMonitor = new Object();
 
-    // 트레이스는 로그인 비밀번호 입력·계정/예치금 등 민감 정보를 캡처하므로, refresh로 즉시 끌 수 있도록
-    // 생성 시점 캡처(@Value) 대신 재바인딩되는 LottoProperties에서 매 호출 시 현재 값을 읽는다.
+    // 트레이스는 로그인 비밀번호 입력·계정/예치금 등 민감 정보를 캡처하므로 기본 비활성화한다.
     private final LottoProperties lottoProperties;
 
     @Value("${logging.file.path:./logs}")

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightTraceArchive.java
@@ -21,6 +21,7 @@ import org.springframework.stereotype.Component;
 public class PlaywrightTraceArchive {
 
     private static final DateTimeFormatter TIMESTAMP_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd_HH-mm-ss");
+    private static final String TRACE_GLOB = "lotto-trace-*.zip";
     private final Object cleanupMonitor = new Object();
 
     @Value("${logging.file.path:./logs}")
@@ -28,6 +29,10 @@ public class PlaywrightTraceArchive {
 
     @Value("${logging.logback.rollingpolicy.max-history:7}")
     private int maxTraceFiles;
+
+    // 트레이스는 로그인 비밀번호 입력·계정/예치금 등 민감 정보를 캡처하므로 기본 비활성화한다.
+    @Value("${lotto.trace-enabled:false}")
+    private boolean traceEnabled;
 
     @PostConstruct
     void initialize() {
@@ -40,6 +45,9 @@ public class PlaywrightTraceArchive {
     }
 
     public void start(BrowserContext context) {
+        if (!traceEnabled) {
+            return;
+        }
         context.tracing().start(new Tracing.StartOptions()
                 .setScreenshots(true)
                 .setSnapshots(true)
@@ -47,6 +55,9 @@ public class PlaywrightTraceArchive {
     }
 
     public void stop(BrowserContext context) {
+        if (!traceEnabled) {
+            return;
+        }
         try {
             String timestamp = LocalDateTime.now().format(TIMESTAMP_FORMATTER);
             String traceId = UUID.randomUUID().toString().substring(0, 8);
@@ -64,7 +75,7 @@ public class PlaywrightTraceArchive {
 
     private void cleanupOldTraceFiles() throws IOException {
         synchronized (cleanupMonitor) {
-            try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(logPath), "*.zip")) {
+            try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(logPath), TRACE_GLOB)) {
                 StreamSupport.stream(stream.spliterator(), false)
                         .sorted((first, second) -> {
                             try {

--- a/src/main/java/org/nowstart/lotto/adapter/out/mail/NotificationMailAdapter.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/mail/NotificationMailAdapter.java
@@ -10,6 +10,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.stereotype.Component;
+import org.springframework.web.util.HtmlUtils;
 
 @Slf4j
 @Component
@@ -17,6 +18,7 @@ import org.springframework.stereotype.Component;
 public class NotificationMailAdapter implements SendNotificationPort {
 
     private static final String CONTENT_ID = "lottoImage";
+    private static final String INLINE_IMAGE_CONTENT_TYPE = "image/png";
 
     @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
     private final JavaMailSender javaMailSender;
@@ -33,8 +35,10 @@ public class NotificationMailAdapter implements SendNotificationPort {
             helper.setSubject(message.subject());
 
             if (message.hasInlineImage()) {
-                helper.setText(message.text() + "<br/><br/><img src='cid:" + CONTENT_ID + "'/>", true);
-                helper.addInline(CONTENT_ID, new ByteArrayResource(message.inlineImage()));
+                String htmlBody = HtmlUtils.htmlEscape(message.text()).replace("\n", "<br/>")
+                        + "<br/><br/><img src='cid:" + CONTENT_ID + "'/>";
+                helper.setText(htmlBody, true);
+                helper.addInline(CONTENT_ID, new ByteArrayResource(message.inlineImage()), INLINE_IMAGE_CONTENT_TYPE);
             } else {
                 helper.setText(message.text(), false);
             }

--- a/src/main/java/org/nowstart/lotto/application/port/out/LottoAutomationPort.java
+++ b/src/main/java/org/nowstart/lotto/application/port/out/LottoAutomationPort.java
@@ -3,6 +3,8 @@ package org.nowstart.lotto.application.port.out;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
 
 public interface LottoAutomationPort {
@@ -11,7 +13,12 @@ public interface LottoAutomationPort {
 
     LottoAccountSnapshot login(LottoAutomationSession session, LottoUser user);
 
-    PurchaseReceipt buy(LottoAutomationSession session, LottoUser user);
+    /**
+     * @param abortRequested 최종 확정(실결제) 직전 확인용 중단 신호. true면 확정 클릭을 하지 않고
+     *                       Optional.empty()를 반환한다(구매 미수행).
+     * @return 구매 영수증. 최종 확정 전에 중단되면 Optional.empty().
+     */
+    Optional<PurchaseReceipt> buy(LottoAutomationSession session, LottoUser user, BooleanSupplier abortRequested);
 
     List<CheckResult> check(LottoAutomationSession session);
 

--- a/src/main/java/org/nowstart/lotto/application/port/out/LottoAutomationSession.java
+++ b/src/main/java/org/nowstart/lotto/application/port/out/LottoAutomationSession.java
@@ -2,6 +2,9 @@ package org.nowstart.lotto.application.port.out;
 
 public interface LottoAutomationSession extends AutoCloseable {
 
+    default void markFailed() {
+    }
+
     @Override
     void close();
 }

--- a/src/main/java/org/nowstart/lotto/application/service/InitializeLottoInteractor.java
+++ b/src/main/java/org/nowstart/lotto/application/service/InitializeLottoInteractor.java
@@ -31,9 +31,14 @@ public class InitializeLottoInteractor implements InitializeLottoUseCase {
 
             log.info("[Init][{}] Start", user.id());
             try (LottoAutomationSession session = lottoAutomationPort.openSession()) {
-                LottoAccountSnapshot accountSnapshot = lottoAutomationPort.login(session, user);
-                sendNotificationPort.send(lottoNotificationFactory.createInitializationMessage(user, accountSnapshot));
-                log.info("[Init][{}] Success deposit={}", user.id(), accountSnapshot.deposit());
+                try {
+                    LottoAccountSnapshot accountSnapshot = lottoAutomationPort.login(session, user);
+                    sendNotificationPort.send(lottoNotificationFactory.createInitializationMessage(user, accountSnapshot));
+                    log.info("[Init][{}] Success deposit={}", user.id(), accountSnapshot.deposit());
+                } catch (RuntimeException | Error exception) {
+                    session.markFailed();
+                    throw exception;
+                }
             } catch (Exception exception) {
                 log.error("[Init][{}] Failed", user.id(), exception);
             }

--- a/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
@@ -59,8 +59,10 @@ public class LottoInteractor implements LottoUseCase {
 
         UserExecutionCounts counts = runUsers(targetUsers, mode);
         int successUsers = counts.successUsers();
-        int failedUsers = counts.failedUsers();
         int skippedUsers = counts.skippedUsers();
+        // 이 호출에서 실행되지 못한 skip 사용자(다른 실행이 선점)도 '비성공'으로 집계한다.
+        // 그러지 않으면 전량 skip 시 totalUsers=0 → ExecutionStatus.fromCounts(0,0)=SUCCESS 로 오인된다.
+        int failedUsers = counts.failedUsers() + skippedUsers;
 
         Instant endedAt = Instant.now();
         long durationMs = (System.nanoTime() - startedNano) / 1_000_000;
@@ -80,7 +82,7 @@ public class LottoInteractor implements LottoUseCase {
         );
 
         log.info("[Task] Batch complete mode={} trigger={} status={} success={} failed={} skipped={} durationMs={}",
-                mode, trigger, status, successUsers, failedUsers, skippedUsers, durationMs);
+                mode, trigger, status, successUsers, counts.failedUsers(), skippedUsers, durationMs);
 
         return execution;
     }
@@ -95,16 +97,20 @@ public class LottoInteractor implements LottoUseCase {
                 log.warn("[Task][{}] Skip - 동일 사용자 작업이 이미 실행 중 mode={}", user.id(), mode);
                 continue;
             }
+            // per-user 타임아웃 기준점을 '제출 시점'으로 고정한다 — join 시점 기준이면 앞선 hung 사용자를
+            // 기다린 시간만큼 뒤 사용자의 제한이 늘어나(N배) 설정값을 크게 초과할 수 있다.
+            long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(lottoProperties.getUserTaskTimeoutMs());
             CompletableFuture<Boolean> future;
             try {
                 future = lottoUserRunner.runAsync(user, mode);
-            } catch (RuntimeException submitError) {
+            } catch (RuntimeException | Error submitError) {
+                // 제출 실패(프록시/러너 치명 오류 등) 시 키가 남아 이후 실행이 영구 skip되지 않도록 해제 후 전파.
                 inFlightKeys.remove(key);
                 throw submitError;
             }
             // 실제 작업 종료(성공/실패/취소) 시점에만 in-flight 키를 해제한다.
             future.whenComplete((result, error) -> inFlightKeys.remove(key));
-            userTasks.add(new UserTask(user, key, future));
+            userTasks.add(new UserTask(user, key, deadlineNanos, future));
         }
 
         try {
@@ -125,8 +131,9 @@ public class LottoInteractor implements LottoUseCase {
     }
 
     private boolean joinUserTask(UserTask userTask, TaskMode mode) {
+        long remainingMs = Math.max(0L, (userTask.deadlineNanos() - System.nanoTime()) / 1_000_000L);
         try {
-            return userTask.future().get(lottoProperties.getUserTaskTimeoutMs(), TimeUnit.MILLISECONDS);
+            return userTask.future().get(remainingMs, TimeUnit.MILLISECONDS);
         } catch (ExecutionException exception) {
             Throwable cause = exception.getCause();
             if (cause instanceof Error error) {
@@ -138,7 +145,7 @@ public class LottoInteractor implements LottoUseCase {
         } catch (TimeoutException exception) {
             // 호출자 대기만 종료한다. 실제 작업은 백그라운드에서 계속될 수 있으며,
             // in-flight 키는 whenComplete가 실제 종료 시 해제하므로 중복 실행은 막힌 상태로 유지된다.
-            log.error("[Task][{}] Timed out mode={} after {}ms (작업은 백그라운드에서 계속될 수 있음)",
+            log.error("[Task][{}] Timed out mode={} (제한 {}ms 초과, 작업은 백그라운드에서 계속될 수 있음)",
                     userTask.user().id(), mode, lottoProperties.getUserTaskTimeoutMs());
             return false;
         } catch (InterruptedException exception) {
@@ -182,7 +189,7 @@ public class LottoInteractor implements LottoUseCase {
                 .toList();
     }
 
-    private record UserTask(LottoUser user, String key, CompletableFuture<Boolean> future) {
+    private record UserTask(LottoUser user, String key, long deadlineNanos, CompletableFuture<Boolean> future) {
     }
 
     private record UserExecutionCounts(int successUsers, int failedUsers, int skippedUsers) {

--- a/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
@@ -106,8 +106,10 @@ public class LottoInteractor implements LottoUseCase {
             try {
                 future = lottoUserRunner.runAsync(user, mode, abortSignal);
             } catch (RuntimeException | Error submitError) {
-                // 제출 실패(프록시/러너 치명 오류 등) 시 키가 남아 이후 실행이 영구 skip되지 않도록 해제 후 전파.
+                // 제출 실패(프록시/러너 치명 오류 등) 시: 현재 사용자 키 해제 + 이미 제출된 이전 작업들도
+                // 중단 신호/취소하여, 실패한 이 호출 이후 이전 작업이 뒤늦게 실구매하지 않도록 한다.
                 inFlightKeys.remove(key);
+                cancelRemaining(userTasks);
                 throw submitError;
             }
             // 실제 작업 종료(성공/실패/취소) 시점에만 in-flight 키를 해제한다.

--- a/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
@@ -6,12 +6,17 @@ import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.in.LottoUseCase;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort;
+import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.domain.exception.InvalidManualUserSelectionException;
 import org.nowstart.lotto.application.port.in.LottoUseCase.LottoExecution;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
@@ -27,6 +32,12 @@ public class LottoInteractor implements LottoUseCase {
 
     private final LoadLottoUsersPort loadLottoUsersPort;
     private final LottoUserRunner lottoUserRunner;
+    private final LottoProperties lottoProperties;
+
+    // 인스턴스 내 중복 실행 방지(수동 API + 스케줄 동시 실행 등). 다중 인스턴스 환경은 분산 락/리더 선출이 별도로 필요하다.
+    // 키는 실제 비동기 작업이 종료될 때(whenComplete) 해제한다 — 호출자 타임아웃 시점에 해제하면
+    // 작업이 백그라운드에서 계속 도는 동안 같은 사용자의 중복 실행이 시작될 수 있으므로 금물.
+    private final Set<String> inFlightKeys = ConcurrentHashMap.newKeySet();
 
     @Override
     public LottoExecution check(TargetCommand command) {
@@ -46,13 +57,14 @@ public class LottoInteractor implements LottoUseCase {
         Instant startedAt = Instant.now();
         long startedNano = System.nanoTime();
 
-        UserExecutionCounts userExecutionCounts = runUsers(targetUsers, mode);
-        int successUsers = userExecutionCounts.successUsers();
-        int failedUsers = userExecutionCounts.failedUsers();
+        UserExecutionCounts counts = runUsers(targetUsers, mode);
+        int successUsers = counts.successUsers();
+        int failedUsers = counts.failedUsers();
+        int skippedUsers = counts.skippedUsers();
 
         Instant endedAt = Instant.now();
         long durationMs = (System.nanoTime() - startedNano) / 1_000_000;
-        int totalUsers = targetUsers.size();
+        int totalUsers = successUsers + failedUsers;
         ExecutionStatus status = ExecutionStatus.fromCounts(totalUsers, failedUsers);
 
         LottoExecution execution = new LottoExecution(
@@ -67,19 +79,35 @@ public class LottoInteractor implements LottoUseCase {
                 failedUsers
         );
 
-        log.info("[Task] Batch complete mode={} trigger={} status={} success={} failed={} durationMs={}",
-                mode, trigger, status, successUsers, failedUsers, durationMs);
+        log.info("[Task] Batch complete mode={} trigger={} status={} success={} failed={} skipped={} durationMs={}",
+                mode, trigger, status, successUsers, failedUsers, skippedUsers, durationMs);
 
         return execution;
     }
 
     private UserExecutionCounts runUsers(List<LottoUser> targetUsers, TaskMode mode) {
         List<UserTask> userTasks = new ArrayList<>();
-        try {
-            for (LottoUser user : targetUsers) {
-                userTasks.add(new UserTask(user, lottoUserRunner.runAsync(user, mode)));
+        int skippedUsers = 0;
+        for (LottoUser user : targetUsers) {
+            String key = mode + ":" + user.id();
+            if (!inFlightKeys.add(key)) {
+                skippedUsers++;
+                log.warn("[Task][{}] Skip - 동일 사용자 작업이 이미 실행 중 mode={}", user.id(), mode);
+                continue;
             }
+            CompletableFuture<Boolean> future;
+            try {
+                future = lottoUserRunner.runAsync(user, mode);
+            } catch (RuntimeException submitError) {
+                inFlightKeys.remove(key);
+                throw submitError;
+            }
+            // 실제 작업 종료(성공/실패/취소) 시점에만 in-flight 키를 해제한다.
+            future.whenComplete((result, error) -> inFlightKeys.remove(key));
+            userTasks.add(new UserTask(user, key, future));
+        }
 
+        try {
             int successUsers = 0;
             int failedUsers = 0;
             for (UserTask userTask : userTasks) {
@@ -89,7 +117,7 @@ public class LottoInteractor implements LottoUseCase {
                     failedUsers++;
                 }
             }
-            return new UserExecutionCounts(successUsers, failedUsers);
+            return new UserExecutionCounts(successUsers, failedUsers, skippedUsers);
         } catch (Error error) {
             cancelRemaining(userTasks);
             throw error;
@@ -98,14 +126,24 @@ public class LottoInteractor implements LottoUseCase {
 
     private boolean joinUserTask(UserTask userTask, TaskMode mode) {
         try {
-            return userTask.future().join();
-        } catch (CompletionException exception) {
+            return userTask.future().get(lottoProperties.getUserTaskTimeoutMs(), TimeUnit.MILLISECONDS);
+        } catch (ExecutionException exception) {
             Throwable cause = exception.getCause();
             if (cause instanceof Error error) {
                 throw error;
             }
             log.error("[Task][{}] Failed mode={} step=async", userTask.user().id(), mode,
                     cause == null ? exception : cause);
+            return false;
+        } catch (TimeoutException exception) {
+            // 호출자 대기만 종료한다. 실제 작업은 백그라운드에서 계속될 수 있으며,
+            // in-flight 키는 whenComplete가 실제 종료 시 해제하므로 중복 실행은 막힌 상태로 유지된다.
+            log.error("[Task][{}] Timed out mode={} after {}ms (작업은 백그라운드에서 계속될 수 있음)",
+                    userTask.user().id(), mode, lottoProperties.getUserTaskTimeoutMs());
+            return false;
+        } catch (InterruptedException exception) {
+            Thread.currentThread().interrupt();
+            log.error("[Task][{}] Interrupted mode={}", userTask.user().id(), mode, exception);
             return false;
         }
     }
@@ -144,9 +182,9 @@ public class LottoInteractor implements LottoUseCase {
                 .toList();
     }
 
-    private record UserTask(LottoUser user, CompletableFuture<Boolean> future) {
+    private record UserTask(LottoUser user, String key, CompletableFuture<Boolean> future) {
     }
 
-    private record UserExecutionCounts(int successUsers, int failedUsers) {
+    private record UserExecutionCounts(int successUsers, int failedUsers, int skippedUsers) {
     }
 }

--- a/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
@@ -149,10 +149,19 @@ public class LottoInteractor implements LottoUseCase {
         } catch (TimeoutException exception) {
             // 아직 실행/큐잉 중인 작업에 중단 신호를 보낸다 — 세마포어 대기 중이던 작업이 뒤늦게
             // 실거래(구매)를 수행하는 것을 방지(러너가 구매 직전 abortSignal을 확인한다).
-            // 실제 작업은 백그라운드에서 안전하게 종료되며, in-flight 키는 whenComplete가 해제한다.
+            // 실제 작업은 백그라운드에서 안전하게 종료되며, in-flight 키는 whenComplete가 실제 종료 시 해제한다.
             userTask.abortSignal().set(true);
-            log.error("[Task][{}] Timed out mode={} (제한 {}ms 초과 - 중단 신호 전송, 작업은 안전 지점에서 종료됨)",
-                    userTask.user().id(), mode, lottoProperties.getUserTaskTimeoutMs());
+            if (mode == TaskMode.PURCHASE) {
+                // 최종 확정 이후 타임아웃이면 구매가 성사됐을 수 있어 결과는 '불확실'하다(단정된 실패 아님).
+                // 실제 성사 여부는 백그라운드 원장 확인/메일이 판정하며, in-flight 키가 실제 종료까지 유지되어
+                // 동일 사용자의 중복 구매 실행(수동/스케줄 재시도)을 막는다. 재시도 전 메일/원장으로 확인할 것.
+                log.error("[Task][{}] PURCHASE timed out mode={} (제한 {}ms 초과) - 결과 불확실: "
+                                + "실제 구매 성사 여부는 백그라운드 원장 확인/메일로 판정, 중복 방지 위해 in-flight 키 유지",
+                        userTask.user().id(), mode, lottoProperties.getUserTaskTimeoutMs());
+            } else {
+                log.error("[Task][{}] Timed out mode={} (제한 {}ms 초과 - 중단 신호 전송, 작업은 안전 지점에서 종료됨)",
+                        userTask.user().id(), mode, lottoProperties.getUserTaskTimeoutMs());
+            }
             return false;
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();

--- a/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoInteractor.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.in.LottoUseCase;
@@ -100,9 +101,10 @@ public class LottoInteractor implements LottoUseCase {
             // per-user 타임아웃 기준점을 '제출 시점'으로 고정한다 — join 시점 기준이면 앞선 hung 사용자를
             // 기다린 시간만큼 뒤 사용자의 제한이 늘어나(N배) 설정값을 크게 초과할 수 있다.
             long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(lottoProperties.getUserTaskTimeoutMs());
+            AtomicBoolean abortSignal = new AtomicBoolean(false);
             CompletableFuture<Boolean> future;
             try {
-                future = lottoUserRunner.runAsync(user, mode);
+                future = lottoUserRunner.runAsync(user, mode, abortSignal);
             } catch (RuntimeException | Error submitError) {
                 // 제출 실패(프록시/러너 치명 오류 등) 시 키가 남아 이후 실행이 영구 skip되지 않도록 해제 후 전파.
                 inFlightKeys.remove(key);
@@ -110,7 +112,7 @@ public class LottoInteractor implements LottoUseCase {
             }
             // 실제 작업 종료(성공/실패/취소) 시점에만 in-flight 키를 해제한다.
             future.whenComplete((result, error) -> inFlightKeys.remove(key));
-            userTasks.add(new UserTask(user, key, deadlineNanos, future));
+            userTasks.add(new UserTask(user, key, deadlineNanos, abortSignal, future));
         }
 
         try {
@@ -143,23 +145,28 @@ public class LottoInteractor implements LottoUseCase {
                     cause == null ? exception : cause);
             return false;
         } catch (TimeoutException exception) {
-            // 호출자 대기만 종료한다. 실제 작업은 백그라운드에서 계속될 수 있으며,
-            // in-flight 키는 whenComplete가 실제 종료 시 해제하므로 중복 실행은 막힌 상태로 유지된다.
-            log.error("[Task][{}] Timed out mode={} (제한 {}ms 초과, 작업은 백그라운드에서 계속될 수 있음)",
+            // 아직 실행/큐잉 중인 작업에 중단 신호를 보낸다 — 세마포어 대기 중이던 작업이 뒤늦게
+            // 실거래(구매)를 수행하는 것을 방지(러너가 구매 직전 abortSignal을 확인한다).
+            // 실제 작업은 백그라운드에서 안전하게 종료되며, in-flight 키는 whenComplete가 해제한다.
+            userTask.abortSignal().set(true);
+            log.error("[Task][{}] Timed out mode={} (제한 {}ms 초과 - 중단 신호 전송, 작업은 안전 지점에서 종료됨)",
                     userTask.user().id(), mode, lottoProperties.getUserTaskTimeoutMs());
             return false;
         } catch (InterruptedException exception) {
             Thread.currentThread().interrupt();
+            userTask.abortSignal().set(true);
             log.error("[Task][{}] Interrupted mode={}", userTask.user().id(), mode, exception);
             return false;
         }
     }
 
     private void cancelRemaining(List<UserTask> userTasks) {
-        userTasks.stream()
-                .map(UserTask::future)
-                .filter(future -> !future.isDone())
-                .forEach(future -> future.cancel(true));
+        userTasks.forEach(userTask -> {
+            userTask.abortSignal().set(true);
+            if (!userTask.future().isDone()) {
+                userTask.future().cancel(true);
+            }
+        });
     }
 
     private List<LottoUser> resolveTargetUsers(List<String> requestedUserIds) {
@@ -189,7 +196,13 @@ public class LottoInteractor implements LottoUseCase {
                 .toList();
     }
 
-    private record UserTask(LottoUser user, String key, long deadlineNanos, CompletableFuture<Boolean> future) {
+    private record UserTask(
+            LottoUser user,
+            String key,
+            long deadlineNanos,
+            AtomicBoolean abortSignal,
+            CompletableFuture<Boolean> future
+    ) {
     }
 
     private record UserExecutionCounts(int successUsers, int failedUsers, int skippedUsers) {

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -87,11 +87,18 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
             return false;
         }
 
-        lottoNotificationFactory.createCheckSuccessMessage(user, accountSnapshot, results)
-                .ifPresent(message -> sendNotification(user, message, "success"));
-
-        log.info("[Task][{}] Success mode={} deposit={}", user.id(), mode, accountSnapshot.deposit());
-        return true;
+        try {
+            lottoNotificationFactory.createCheckSuccessMessage(user, accountSnapshot, results)
+                    .ifPresent(message -> sendNotification(user, message, "success"));
+            log.info("[Task][{}] Success mode={} deposit={}", user.id(), mode, accountSnapshot.deposit());
+            return true;
+        } catch (Exception exception) {
+            // 성공 메시지 포맷팅(스크랩 데이터 파싱 등) 중 오류가 나도 사용자에게 실패 통지를 보낸다.
+            // (브라우저 작업은 끝났고 세션이 닫혀 permit이 해제된 상태라 통지가 브라우저 슬롯을 점유하지 않는다)
+            log.error("[Task][{}] Failed mode={} step=notify", user.id(), mode, exception);
+            sendNotification(user, lottoNotificationFactory.createFailureMessage(user, mode, exception), "failure");
+            return false;
+        }
     }
 
     /**

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -62,6 +62,13 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
                 if (purchaseReceipt.isEmpty()) {
                     log.warn("[Task][{}] Aborted before final purchase confirmation (호출자 타임아웃) mode={}",
                             user.id(), mode);
+                    // 예외 경로와 동일하게 실패 통지를 보낸다 — 스케줄 구매가 조용히 누락되지 않도록.
+                    LottoAutomationException abortException = new LottoAutomationException(
+                            StepType.PURCHASE,
+                            user.id(),
+                            new IllegalStateException("호출자 타임아웃으로 최종 확정 전 구매가 중단되었습니다"));
+                    sendNotification(user,
+                            lottoNotificationFactory.createFailureMessage(user, mode, abortException), "failure");
                     return false;
                 }
                 CheckResult latestPurchaseResult = runStep(

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -57,7 +57,7 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
                         () -> lottoAutomationPort.buy(session, user, abortSignal::get)
                 );
                 if (purchaseReceipt.isEmpty()) {
-                    return aborted(user, mode, "최종 확정 직전");
+                    return aborted(user, mode, "최종 확정 미제출/중단");
                 }
                 CheckResult latestPurchaseResult = runStep(
                         StepType.CHECK,
@@ -104,7 +104,7 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
             LottoAutomationException abortException = new LottoAutomationException(
                     StepType.PURCHASE,
                     user.id(),
-                    new IllegalStateException("호출자 타임아웃으로 구매가 중단되었습니다 (" + phase + ")"));
+                    new IllegalStateException("구매가 최종 확정 전에 중단/미제출되었습니다 (" + phase + ")"));
             sendNotification(user, lottoNotificationFactory.createFailureMessage(user, mode, abortException), "failure");
         }
         return false;

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -2,6 +2,7 @@ package org.nowstart.lotto.application.service;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
@@ -29,12 +30,21 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
 
     @Async("lottoTaskExecutor")
     @Override
-    public CompletableFuture<Boolean> runAsync(LottoUser user, TaskMode mode) {
-        return CompletableFuture.completedFuture(runUser(user, mode));
+    public CompletableFuture<Boolean> runAsync(LottoUser user, TaskMode mode, AtomicBoolean abortSignal) {
+        return CompletableFuture.completedFuture(runUser(user, mode, abortSignal));
     }
 
-    private boolean runUser(LottoUser user, TaskMode mode) {
+    private boolean runUser(LottoUser user, TaskMode mode, AtomicBoolean abortSignal) {
+        if (abortSignal.get()) {
+            log.warn("[Task][{}] Aborted before start (호출자 타임아웃) mode={}", user.id(), mode);
+            return false;
+        }
         try (LottoAutomationSession session = lottoAutomationPort.openSession()) {
+            // 세션 확보(세마포어 대기 포함) 이후, 어떤 사이트 조작보다 먼저 취소 여부를 재확인한다.
+            if (abortSignal.get()) {
+                log.warn("[Task][{}] Aborted after acquiring session (호출자 타임아웃) mode={}", user.id(), mode);
+                return false;
+            }
             log.info("[Task][{}] Start mode={}", user.id(), mode);
 
             LottoAccountSnapshot accountSnapshot = runStep(StepType.LOGIN, user,
@@ -42,6 +52,11 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
 
             List<CheckResult> results;
             if (mode == TaskMode.PURCHASE) {
+                // 실거래(구매) 직전 최종 확인 — 타임아웃으로 큐잉되었던 작업이 뒤늦게 실구매하는 것을 막는다.
+                if (abortSignal.get()) {
+                    log.warn("[Task][{}] Aborted before purchase (호출자 타임아웃) mode={}", user.id(), mode);
+                    return false;
+                }
                 PurchaseReceipt purchaseReceipt = runStep(
                         StepType.PURCHASE,
                         user,

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -37,52 +37,37 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
 
     private boolean runUser(LottoUser user, TaskMode mode, AtomicBoolean abortSignal) {
         if (abortSignal.get()) {
+            // 세션을 열기 전이라 브라우저 permit을 잡지 않은 상태 → 바로 통지해도 무방.
             return aborted(user, mode, "작업 시작 전");
         }
+
+        // 브라우저 작업은 try-with-resources 안에서만 수행하고, 통지(SMTP)는 세션이 닫혀 permit이 해제된 뒤에 보낸다.
+        // (성공/실패/중단 통지가 브라우저 슬롯을 붙잡아 다른 사용자가 세마포어에서 대기하는 것을 방지)
+        LottoAccountSnapshot accountSnapshot = null;
+        List<CheckResult> results = null;
+        String abortPhase = null;
         try (LottoAutomationSession session = lottoAutomationPort.openSession()) {
-            // 세션 확보(세마포어 대기 포함) 이후, 어떤 사이트 조작보다 먼저 취소 여부를 재확인한다.
             if (abortSignal.get()) {
-                return aborted(user, mode, "세션 확보 직후");
-            }
-            log.info("[Task][{}] Start mode={}", user.id(), mode);
-
-            LottoAccountSnapshot accountSnapshot = runStep(StepType.LOGIN, user,
-                    () -> lottoAutomationPort.login(session, user));
-
-            List<CheckResult> results;
-            if (mode == TaskMode.PURCHASE) {
-                Optional<PurchaseReceipt> purchaseReceipt = runStep(
-                        StepType.PURCHASE,
-                        user,
-                        () -> lottoAutomationPort.buy(session, user, abortSignal::get)
-                );
-                if (purchaseReceipt.isEmpty()) {
-                    return aborted(user, mode, "최종 확정 미제출/중단");
-                }
-                CheckResult latestPurchaseResult = runStep(
-                        StepType.CHECK,
-                        user,
-                        () -> lottoAutomationPort.check(session, purchaseReceipt.get())
-                );
-                results = List.of(latestPurchaseResult);
+                abortPhase = "세션 확보 직후";
             } else {
-                results = runStep(StepType.CHECK, user, () -> lottoAutomationPort.check(session));
+                log.info("[Task][{}] Start mode={}", user.id(), mode);
+                accountSnapshot = runStep(StepType.LOGIN, user, () -> lottoAutomationPort.login(session, user));
+
+                if (mode == TaskMode.PURCHASE) {
+                    Optional<PurchaseReceipt> purchaseReceipt = runStep(StepType.PURCHASE, user,
+                            () -> lottoAutomationPort.buy(session, user, abortSignal::get));
+                    if (purchaseReceipt.isEmpty()) {
+                        abortPhase = "최종 확정 미제출/중단";
+                    } else {
+                        results = List.of(runStep(StepType.CHECK, user,
+                                () -> lottoAutomationPort.check(session, purchaseReceipt.get())));
+                    }
+                } else {
+                    results = runStep(StepType.CHECK, user, () -> lottoAutomationPort.check(session));
+                }
             }
-
-            // CHECK가 진행되는 동안 호출자 타임아웃(abort)이 발생했다면, 호출자는 이미 실패로 보고했다.
-            // 취소 불가한 조회 결과에 대해 뒤늦게 성공 통지를 보내 상태 불일치를 만들지 않도록 억제한다.
-            // (PURCHASE는 실제 구매가 성사됐을 수 있으므로 성공 통지를 유지해 사용자가 반드시 알 수 있게 한다.)
-            if (mode == TaskMode.CHECK && abortSignal.get()) {
-                log.warn("[Task][{}] Check completed but aborted meanwhile - suppressing success notification", user.id());
-                return false;
-            }
-
-            lottoNotificationFactory.createCheckSuccessMessage(user, accountSnapshot, results)
-                    .ifPresent(message -> sendNotification(user, message, "success"));
-
-            log.info("[Task][{}] Success mode={} deposit={}", user.id(), mode, accountSnapshot.deposit());
-            return true;
         } catch (LottoAutomationException exception) {
+            // try-with-resources가 세션을 이미 닫음(permit 해제) → 아래 통지가 브라우저 슬롯을 점유하지 않는다.
             log.error("[Task][{}] Failed mode={} step={}", user.id(), mode, exception.getStepType(), exception);
             sendNotification(user, lottoNotificationFactory.createFailureMessage(user, mode, exception), "failure");
             return false;
@@ -91,11 +76,26 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
             sendNotification(user, lottoNotificationFactory.createFailureMessage(user, mode, exception), "failure");
             return false;
         }
+
+        // 여기서부터 세션이 닫혀(permit 해제된) 상태 → 통지는 브라우저 슬롯을 붙잡지 않는다.
+        if (abortPhase != null) {
+            return aborted(user, mode, abortPhase);
+        }
+        if (mode == TaskMode.CHECK && abortSignal.get()) {
+            // CHECK 진행 중 호출자 타임아웃 → 호출자는 이미 실패 보고. 뒤늦은 성공 통지로 상태 불일치를 만들지 않는다.
+            log.warn("[Task][{}] Check completed but aborted meanwhile - suppressing success notification", user.id());
+            return false;
+        }
+
+        lottoNotificationFactory.createCheckSuccessMessage(user, accountSnapshot, results)
+                .ifPresent(message -> sendNotification(user, message, "success"));
+
+        log.info("[Task][{}] Success mode={} deposit={}", user.id(), mode, accountSnapshot.deposit());
+        return true;
     }
 
     /**
-     * 호출자 타임아웃 등으로 실제 작업을 수행하기 전에 중단된 경우의 처리.
-     * PURCHASE는 스케줄 구매가 조용히 누락되지 않도록 예외 경로와 동일한 실패 통지를 보낸다.
+     * 실제 작업 수행 전에 중단된 경우의 처리. PURCHASE는 스케줄 구매가 조용히 누락되지 않도록 실패 통지를 보낸다.
      * CHECK는 조회 미수행이 치명적이지 않으므로 통지하지 않는다(호출자가 이미 타임아웃 실패로 보고).
      */
     private boolean aborted(LottoUser user, TaskMode mode, String phase) {

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -37,14 +37,12 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
 
     private boolean runUser(LottoUser user, TaskMode mode, AtomicBoolean abortSignal) {
         if (abortSignal.get()) {
-            log.warn("[Task][{}] Aborted before start (호출자 타임아웃) mode={}", user.id(), mode);
-            return false;
+            return aborted(user, mode, "작업 시작 전");
         }
         try (LottoAutomationSession session = lottoAutomationPort.openSession()) {
             // 세션 확보(세마포어 대기 포함) 이후, 어떤 사이트 조작보다 먼저 취소 여부를 재확인한다.
             if (abortSignal.get()) {
-                log.warn("[Task][{}] Aborted after acquiring session (호출자 타임아웃) mode={}", user.id(), mode);
-                return false;
+                return aborted(user, mode, "세션 확보 직후");
             }
             log.info("[Task][{}] Start mode={}", user.id(), mode);
 
@@ -53,23 +51,13 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
 
             List<CheckResult> results;
             if (mode == TaskMode.PURCHASE) {
-                // 실결제 직전 abort는 구매 executor(buy) 내부에서 최종 확인한다(Optional.empty = 미수행).
                 Optional<PurchaseReceipt> purchaseReceipt = runStep(
                         StepType.PURCHASE,
                         user,
                         () -> lottoAutomationPort.buy(session, user, abortSignal::get)
                 );
                 if (purchaseReceipt.isEmpty()) {
-                    log.warn("[Task][{}] Aborted before final purchase confirmation (호출자 타임아웃) mode={}",
-                            user.id(), mode);
-                    // 예외 경로와 동일하게 실패 통지를 보낸다 — 스케줄 구매가 조용히 누락되지 않도록.
-                    LottoAutomationException abortException = new LottoAutomationException(
-                            StepType.PURCHASE,
-                            user.id(),
-                            new IllegalStateException("호출자 타임아웃으로 최종 확정 전 구매가 중단되었습니다"));
-                    sendNotification(user,
-                            lottoNotificationFactory.createFailureMessage(user, mode, abortException), "failure");
-                    return false;
+                    return aborted(user, mode, "최종 확정 직전");
                 }
                 CheckResult latestPurchaseResult = runStep(
                         StepType.CHECK,
@@ -79,6 +67,14 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
                 results = List.of(latestPurchaseResult);
             } else {
                 results = runStep(StepType.CHECK, user, () -> lottoAutomationPort.check(session));
+            }
+
+            // CHECK가 진행되는 동안 호출자 타임아웃(abort)이 발생했다면, 호출자는 이미 실패로 보고했다.
+            // 취소 불가한 조회 결과에 대해 뒤늦게 성공 통지를 보내 상태 불일치를 만들지 않도록 억제한다.
+            // (PURCHASE는 실제 구매가 성사됐을 수 있으므로 성공 통지를 유지해 사용자가 반드시 알 수 있게 한다.)
+            if (mode == TaskMode.CHECK && abortSignal.get()) {
+                log.warn("[Task][{}] Check completed but aborted meanwhile - suppressing success notification", user.id());
+                return false;
             }
 
             lottoNotificationFactory.createCheckSuccessMessage(user, accountSnapshot, results)
@@ -95,6 +91,23 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
             sendNotification(user, lottoNotificationFactory.createFailureMessage(user, mode, exception), "failure");
             return false;
         }
+    }
+
+    /**
+     * 호출자 타임아웃 등으로 실제 작업을 수행하기 전에 중단된 경우의 처리.
+     * PURCHASE는 스케줄 구매가 조용히 누락되지 않도록 예외 경로와 동일한 실패 통지를 보낸다.
+     * CHECK는 조회 미수행이 치명적이지 않으므로 통지하지 않는다(호출자가 이미 타임아웃 실패로 보고).
+     */
+    private boolean aborted(LottoUser user, TaskMode mode, String phase) {
+        log.warn("[Task][{}] Aborted ({}) - 호출자 타임아웃 mode={}", user.id(), phase, mode);
+        if (mode == TaskMode.PURCHASE) {
+            LottoAutomationException abortException = new LottoAutomationException(
+                    StepType.PURCHASE,
+                    user.id(),
+                    new IllegalStateException("호출자 타임아웃으로 구매가 중단되었습니다 (" + phase + ")"));
+            sendNotification(user, lottoNotificationFactory.createFailureMessage(user, mode, abortException), "failure");
+        }
+        return false;
     }
 
     private void sendNotification(LottoUser user, NotificationMessage message, String kind) {

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -1,6 +1,7 @@
 package org.nowstart.lotto.application.service;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import lombok.RequiredArgsConstructor;
@@ -52,20 +53,21 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
 
             List<CheckResult> results;
             if (mode == TaskMode.PURCHASE) {
-                // 실거래(구매) 직전 최종 확인 — 타임아웃으로 큐잉되었던 작업이 뒤늦게 실구매하는 것을 막는다.
-                if (abortSignal.get()) {
-                    log.warn("[Task][{}] Aborted before purchase (호출자 타임아웃) mode={}", user.id(), mode);
-                    return false;
-                }
-                PurchaseReceipt purchaseReceipt = runStep(
+                // 실결제 직전 abort는 구매 executor(buy) 내부에서 최종 확인한다(Optional.empty = 미수행).
+                Optional<PurchaseReceipt> purchaseReceipt = runStep(
                         StepType.PURCHASE,
                         user,
-                        () -> lottoAutomationPort.buy(session, user)
+                        () -> lottoAutomationPort.buy(session, user, abortSignal::get)
                 );
+                if (purchaseReceipt.isEmpty()) {
+                    log.warn("[Task][{}] Aborted before final purchase confirmation (호출자 타임아웃) mode={}",
+                            user.id(), mode);
+                    return false;
+                }
                 CheckResult latestPurchaseResult = runStep(
                         StepType.CHECK,
                         user,
-                        () -> lottoAutomationPort.check(session, purchaseReceipt)
+                        () -> lottoAutomationPort.check(session, purchaseReceipt.get())
                 );
                 results = List.of(latestPurchaseResult);
             } else {

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserAsyncRunner.java
@@ -46,25 +46,38 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
         LottoAccountSnapshot accountSnapshot = null;
         List<CheckResult> results = null;
         String abortPhase = null;
+        boolean checkAbortedAfterCompletion = false;
         try (LottoAutomationSession session = lottoAutomationPort.openSession()) {
-            if (abortSignal.get()) {
-                abortPhase = "세션 확보 직후";
-            } else {
-                log.info("[Task][{}] Start mode={}", user.id(), mode);
-                accountSnapshot = runStep(StepType.LOGIN, user, () -> lottoAutomationPort.login(session, user));
-
-                if (mode == TaskMode.PURCHASE) {
-                    Optional<PurchaseReceipt> purchaseReceipt = runStep(StepType.PURCHASE, user,
-                            () -> lottoAutomationPort.buy(session, user, abortSignal::get));
-                    if (purchaseReceipt.isEmpty()) {
-                        abortPhase = "최종 확정 미제출/중단";
-                    } else {
-                        results = List.of(runStep(StepType.CHECK, user,
-                                () -> lottoAutomationPort.check(session, purchaseReceipt.get())));
-                    }
+            try {
+                if (abortSignal.get()) {
+                    session.markFailed();
+                    abortPhase = "세션 확보 직후";
                 } else {
-                    results = runStep(StepType.CHECK, user, () -> lottoAutomationPort.check(session));
+                    log.info("[Task][{}] Start mode={}", user.id(), mode);
+                    accountSnapshot = runStep(StepType.LOGIN, user, () -> lottoAutomationPort.login(session, user));
+
+                    if (mode == TaskMode.PURCHASE) {
+                        Optional<PurchaseReceipt> purchaseReceipt = runStep(StepType.PURCHASE, user,
+                                () -> lottoAutomationPort.buy(session, user, abortSignal::get));
+                        if (purchaseReceipt.isEmpty()) {
+                            session.markFailed();
+                            abortPhase = "최종 확정 미제출/중단";
+                        } else {
+                            results = List.of(runStep(StepType.CHECK, user,
+                                    () -> lottoAutomationPort.check(session, purchaseReceipt.get())));
+                        }
+                    } else {
+                        results = runStep(StepType.CHECK, user, () -> lottoAutomationPort.check(session));
+                    }
                 }
+
+                if (abortPhase == null && mode == TaskMode.CHECK && abortSignal.get()) {
+                    session.markFailed();
+                    checkAbortedAfterCompletion = true;
+                }
+            } catch (RuntimeException | Error exception) {
+                session.markFailed();
+                throw exception;
             }
         } catch (LottoAutomationException exception) {
             // try-with-resources가 세션을 이미 닫음(permit 해제) → 아래 통지가 브라우저 슬롯을 점유하지 않는다.
@@ -81,7 +94,7 @@ public class LottoUserAsyncRunner implements LottoUserRunner {
         if (abortPhase != null) {
             return aborted(user, mode, abortPhase);
         }
-        if (mode == TaskMode.CHECK && abortSignal.get()) {
+        if (checkAbortedAfterCompletion || mode == TaskMode.CHECK && abortSignal.get()) {
             // CHECK 진행 중 호출자 타임아웃 → 호출자는 이미 실패 보고. 뒤늦은 성공 통지로 상태 불일치를 만들지 않는다.
             log.warn("[Task][{}] Check completed but aborted meanwhile - suppressing success notification", user.id());
             return false;

--- a/src/main/java/org/nowstart/lotto/application/service/LottoUserRunner.java
+++ b/src/main/java/org/nowstart/lotto/application/service/LottoUserRunner.java
@@ -1,10 +1,15 @@
 package org.nowstart.lotto.application.service;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
 import org.nowstart.lotto.domain.type.TaskMode;
 
 public interface LottoUserRunner {
 
-    CompletableFuture<Boolean> runAsync(LottoUser user, TaskMode mode);
+    /**
+     * @param abortSignal 호출자 타임아웃 등으로 작업을 중단시키기 위한 신호. 러너는 세션 확보/로그인/구매 등
+     *                    안전 지점에서 이 값을 확인해, 특히 실거래(구매) 직전에는 반드시 확인 후 중단한다.
+     */
+    CompletableFuture<Boolean> runAsync(LottoUser user, TaskMode mode, AtomicBoolean abortSignal);
 }

--- a/src/main/java/org/nowstart/lotto/config/LottoProperties.java
+++ b/src/main/java/org/nowstart/lotto/config/LottoProperties.java
@@ -47,9 +47,6 @@ public class LottoProperties {
     @NotNull(message = "동시 실행 세션 수는 필수입니다")
     private Integer maxConcurrentSessions = 3;
 
-    @NotNull(message = "트레이스 활성화 여부는 필수입니다")
-    private Boolean traceEnabled = false;
-
     @Min(value = 1000, message = "사용자 작업 타임아웃은 최소 1초여야 합니다")
     @Max(value = 1800000, message = "사용자 작업 타임아웃은 최대 30분까지 가능합니다")
     @NotNull(message = "사용자 작업 타임아웃은 필수입니다")

--- a/src/main/java/org/nowstart/lotto/config/LottoProperties.java
+++ b/src/main/java/org/nowstart/lotto/config/LottoProperties.java
@@ -42,6 +42,19 @@ public class LottoProperties {
     @NotNull(message = "구매 결과 폴링 간격은 필수입니다")
     private Integer purchaseResultPollIntervalMs = 1000;
 
+    @Min(value = 1, message = "동시 실행 세션 수는 최소 1이어야 합니다")
+    @Max(value = 50, message = "동시 실행 세션 수는 최대 50까지 가능합니다")
+    @NotNull(message = "동시 실행 세션 수는 필수입니다")
+    private Integer maxConcurrentSessions = 3;
+
+    @NotNull(message = "트레이스 활성화 여부는 필수입니다")
+    private Boolean traceEnabled = false;
+
+    @Min(value = 1000, message = "사용자 작업 타임아웃은 최소 1초여야 합니다")
+    @Max(value = 1800000, message = "사용자 작업 타임아웃은 최대 30분까지 가능합니다")
+    @NotNull(message = "사용자 작업 타임아웃은 필수입니다")
+    private Integer userTaskTimeoutMs = 180000;
+
     @Valid
     @NotNull(message = "크론 설정은 필수입니다")
     private Cron cron = new Cron();
@@ -78,5 +91,8 @@ public class LottoProperties {
 
         @NotBlank(message = "로또 구매 크론 표현식은 필수입니다")
         private String buy = "0 0 9 * * 0";
+
+        @NotBlank(message = "스케줄러 타임존은 필수입니다")
+        private String zone = "Asia/Seoul";
     }
 }

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -45,7 +45,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: health, info, refresh
+        include: health, info
 
 logging:
   level:

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -61,7 +61,7 @@ lotto:
       init: ${LOTTO_INIT:false}
   max-concurrent-sessions: ${LOTTO_MAX_CONCURRENT_SESSIONS:1}
   user-task-timeout-ms: ${LOTTO_USER_TASK_TIMEOUT_MS:180000}
-  trace-enabled: ${LOTTO_TRACE_ENABLED:true}
+  trace-enabled: ${LOTTO_TRACE_ENABLED:false}
   mail:
     from: ${LOTTO_MAIL_FROM:no-reply@localhost}
   # 스케줄러는 local에서 비활성이라 아래 cron은 사용되지 않지만, 스키마 검증(@NotBlank)을 위해 기본값을 둡니다.

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,0 +1,71 @@
+# ============================================================
+# 로컬 실행 전용 프로파일 (Config Server / Eureka 없이 단독 구동)
+#
+# 실행 예:
+#   SPRING_PROFILES_ACTIVE=local \
+#   SPRING_CONFIG_IMPORT= \
+#   MAIL_USERNAME=your_smtp_id MAIL_PASSWORD=your_smtp_pw \
+#   LOTTO_ID=your_lotto_id LOTTO_PASSWORD=your_lotto_pw LOTTO_EMAIL=you@example.com \
+#   ./gradlew bootRun
+#
+# 주의사항:
+#  - SPRING_CONFIG_IMPORT= (빈 값)로 실행해야 원격 Config Server를 타지 않습니다.
+#    (base application.yaml의 import는 optional이라, 빈 값을 주면 로컬 설정만 사용)
+#  - local 프로파일에서는 스케줄러가 비활성화됩니다(LottoScheduleExecutor @Profile("!local")).
+#    로컬 테스트는 수동 API로: POST /api/lotto/check , POST /api/lotto/buy
+#    (※ /buy 는 실제 구매이므로 로컬에서도 실제 결제가 발생합니다 — 주의)
+#  - Playwright 브라우저는 실행 시 자동 다운로드됩니다. (수동: npx playwright install chromium)
+# ============================================================
+
+server:
+  port: ${SERVER_PORT:8080}
+
+spring:
+  mail:
+    host: ${MAIL_HOST:smtp.gmail.com}
+    port: ${MAIL_PORT:587}
+    username: ${MAIL_USERNAME}
+    password: ${MAIL_PASSWORD}
+    properties:
+      mail:
+        smtp:
+          auth: true
+          starttls:
+            enable: true
+
+# 로컬에서는 서비스 디스커버리 비활성
+eureka:
+  client:
+    enabled: false
+    register-with-eureka: false
+    fetch-registry: false
+
+# 로컬 디버깅용 actuator 노출
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, refresh
+
+logging:
+  level:
+    org.nowstart.lotto: DEBUG
+
+lotto:
+  # @NotEmpty — 최소 1명. 실제 크리덴셜은 환경변수로 주입(하드코딩 금지)
+  users:
+    - id: ${LOTTO_ID}
+      password: ${LOTTO_PASSWORD}
+      email: ${LOTTO_EMAIL}
+      count: ${LOTTO_COUNT:5}
+      init: ${LOTTO_INIT:false}
+  max-concurrent-sessions: ${LOTTO_MAX_CONCURRENT_SESSIONS:1}
+  user-task-timeout-ms: ${LOTTO_USER_TASK_TIMEOUT_MS:180000}
+  trace-enabled: ${LOTTO_TRACE_ENABLED:true}
+  mail:
+    from: ${LOTTO_MAIL_FROM:no-reply@localhost}
+  # 스케줄러는 local에서 비활성이라 아래 cron은 사용되지 않지만, 스키마 검증(@NotBlank)을 위해 기본값을 둡니다.
+  cron:
+    check: ${LOTTO_CRON_CHECK:0 0 22 * * 6}
+    buy: ${LOTTO_CRON_BUY:0 0 9 * * 0}
+    zone: ${LOTTO_CRON_ZONE:Asia/Seoul}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,26 +1,12 @@
-# ============================================================
-# 로컬 실행 전용 프로파일 (Config Server / Eureka 없이 단독 구동)
-#
-# 실행 예:
-#   SPRING_PROFILES_ACTIVE=local \
-#   SPRING_CONFIG_IMPORT= \
-#   MAIL_USERNAME=your_smtp_id MAIL_PASSWORD=your_smtp_pw \
-#   LOTTO_ID=your_lotto_id LOTTO_PASSWORD=your_lotto_pw LOTTO_EMAIL=you@example.com \
-#   ./gradlew bootRun
-#
-# 주의사항:
-#  - SPRING_CONFIG_IMPORT= (빈 값)로 실행해야 원격 Config Server를 타지 않습니다.
-#    (base application.yaml의 import는 optional이라, 빈 값을 주면 로컬 설정만 사용)
-#  - local 프로파일에서는 스케줄러가 비활성화됩니다(LottoScheduleExecutor @Profile("!local")).
-#    로컬 테스트는 수동 API로: POST /api/lotto/check , POST /api/lotto/buy
-#    (※ /buy 는 실제 구매이므로 로컬에서도 실제 결제가 발생합니다 — 주의)
-#  - Playwright 브라우저는 실행 시 자동 다운로드됩니다. (수동: npx playwright install chromium)
-# ============================================================
-
 server:
   port: ${SERVER_PORT:8080}
 
 spring:
+  cloud:
+    config:
+      enabled: false
+    discovery:
+      enabled: false
   mail:
     host: ${MAIL_HOST:smtp.gmail.com}
     port: ${MAIL_PORT:587}
@@ -33,14 +19,12 @@ spring:
           starttls:
             enable: true
 
-# 로컬에서는 서비스 디스커버리 비활성
 eureka:
   client:
     enabled: false
     register-with-eureka: false
     fetch-registry: false
 
-# 로컬 디버깅용 actuator 노출
 management:
   endpoints:
     web:
@@ -52,7 +36,6 @@ logging:
     org.nowstart.lotto: DEBUG
 
 lotto:
-  # @NotEmpty — 최소 1명. 실제 크리덴셜은 환경변수로 주입(하드코딩 금지)
   users:
     - id: ${LOTTO_ID}
       password: ${LOTTO_PASSWORD}
@@ -61,10 +44,8 @@ lotto:
       init: ${LOTTO_INIT:false}
   max-concurrent-sessions: ${LOTTO_MAX_CONCURRENT_SESSIONS:1}
   user-task-timeout-ms: ${LOTTO_USER_TASK_TIMEOUT_MS:180000}
-  trace-enabled: ${LOTTO_TRACE_ENABLED:false}
   mail:
     from: ${LOTTO_MAIL_FROM:no-reply@localhost}
-  # 스케줄러는 local에서 비활성이라 아래 cron은 사용되지 않지만, 스키마 검증(@NotBlank)을 위해 기본값을 둡니다.
   cron:
     check: ${LOTTO_CRON_CHECK:0 0 22 * * 6}
     buy: ${LOTTO_CRON_BUY:0 0 9 * * 0}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,5 +1,11 @@
 spring:
   application:
     name: lotto
+
+---
+
+spring:
   config:
+    activate:
+      on-profile: "!local"
     import: ${SPRING_CONFIG_IMPORT:optional:configserver:https://spring.nowstart.org/config}

--- a/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutorRetryTest.java
+++ b/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutorRetryTest.java
@@ -48,7 +48,7 @@ class PlaywrightPurchaseExecutorRetryTest {
         }).given(autoNumber).click();
 
         // 실행 및 검증: 예외가 그대로 전파되고 단 한 번만 시도한다 (재시도 없음)
-        thenThrownBy(() -> playwrightPurchaseExecutor.buy(page, user))
+        thenThrownBy(() -> playwrightPurchaseExecutor.buy(page, user, () -> false))
                 .isInstanceOf(IllegalStateException.class);
         then(attempts.get()).isEqualTo(1);
         BDDMockito.then(page).should(times(1)).navigate(LottoBrowserConstants.URL_PURCHASE);

--- a/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutorRetryTest.java
+++ b/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightPurchaseExecutorRetryTest.java
@@ -1,6 +1,7 @@
 package org.nowstart.lotto.adapter.out.browser;
 
 import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.BDDAssertions.thenThrownBy;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.mock;
@@ -8,12 +9,10 @@ import static org.mockito.Mockito.times;
 
 import com.microsoft.playwright.Locator;
 import com.microsoft.playwright.Page;
-import com.microsoft.playwright.options.LoadState;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.BDDMockito;
-import org.nowstart.lotto.application.port.out.LottoAutomationPort.PurchaseReceipt;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.TestConfiguration;
@@ -27,51 +26,32 @@ import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
         "lotto.max-retries=3",
         "lotto.retry-delay-ms=1"
 })
-@DisplayName("Playwright 구매 재시도")
+@DisplayName("Playwright 구매 재시도 정책")
 class PlaywrightPurchaseExecutorRetryTest {
 
     @Autowired
     private PlaywrightPurchaseExecutor playwrightPurchaseExecutor;
 
     @Test
-    @DisplayName("자동 번호 선택이 일시 실패하면 설정된 횟수만큼 구매를 재시도한다")
-    void shouldRetryBuyWhenAutoNumberSelectionFailsTransiently() {
-        // 준비: 자동 번호 선택이 두 번 실패한 뒤 성공하는 구매 페이지가 있다
+    @DisplayName("구매는 실패해도 재시도하지 않고 예외를 전파한다 (멱등하지 않은 실거래 보호)")
+    void shouldNotRetryBuyOnFailure() {
+        // 준비: 자동 번호 선택 단계에서 실패하는 구매 페이지가 있다
         Page page = mock(Page.class);
         Locator autoNumber = mock(Locator.class);
-        Locator quantityBox = mock(Locator.class);
-        Locator confirmButton = mock(Locator.class);
-        Locator purchaseButton = mock(Locator.class);
-        Locator finalConfirmButton = mock(Locator.class);
         LottoUser user = new LottoUser("user1", "password", 2, "user1@nowstart.org", false);
-
         given(page.locator(LottoBrowserConstants.AUTO_NUMBER)).willReturn(autoNumber);
-        given(page.locator(LottoBrowserConstants.QUANTITY_BOX)).willReturn(quantityBox);
-        given(page.locator(LottoBrowserConstants.CONFIRM_BTN)).willReturn(confirmButton);
-        given(page.locator(LottoBrowserConstants.PURCHASE_BTN)).willReturn(purchaseButton);
-        given(page.locator(LottoBrowserConstants.FINAL_CONFIRM_BTN)).willReturn(finalConfirmButton);
 
         AtomicInteger attempts = new AtomicInteger();
         willAnswer(invocation -> {
-            if (attempts.incrementAndGet() < 3) {
-                throw new IllegalStateException("temporary");
-            }
-            return null;
+            attempts.incrementAndGet();
+            throw new IllegalStateException("temporary");
         }).given(autoNumber).click();
 
-        // 실행: 구매를 실행한다
-        PurchaseReceipt purchaseReceipt = playwrightPurchaseExecutor.buy(page, user);
-
-        // 검증: 세 번째 시도에서 구매 영수증이 반환되고 각 구매 단계가 실행된다
-        then(purchaseReceipt.count()).isEqualTo(2);
-        then(purchaseReceipt.purchaseDate()).isNotNull();
-        then(attempts.get()).isEqualTo(3);
-        BDDMockito.then(page).should(times(3)).navigate(LottoBrowserConstants.URL_PURCHASE);
-        BDDMockito.then(page).should(times(3)).waitForLoadState(LoadState.NETWORKIDLE);
-        BDDMockito.then(quantityBox).should().selectOption("2");
-        BDDMockito.then(confirmButton).should().click();
-        BDDMockito.then(purchaseButton).should().click();
-        BDDMockito.then(finalConfirmButton).should().click();
+        // 실행 및 검증: 예외가 그대로 전파되고 단 한 번만 시도한다 (재시도 없음)
+        thenThrownBy(() -> playwrightPurchaseExecutor.buy(page, user))
+                .isInstanceOf(IllegalStateException.class);
+        then(attempts.get()).isEqualTo(1);
+        BDDMockito.then(page).should(times(1)).navigate(LottoBrowserConstants.URL_PURCHASE);
     }
 
     @TestConfiguration(proxyBeanMethods = false)

--- a/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightRetryAnnotationTest.java
+++ b/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightRetryAnnotationTest.java
@@ -3,6 +3,7 @@ package org.nowstart.lotto.adapter.out.browser;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import com.microsoft.playwright.Page;
+import com.microsoft.playwright.PlaywrightException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -14,25 +15,29 @@ import org.springframework.resilience.annotation.Retryable;
 class PlaywrightRetryAnnotationTest {
 
     @Test
-    @DisplayName("브라우저 외부 호출 executor는 Retryable 설정을 선언한다")
+    @DisplayName("브라우저 조회 executor는 일시 오류(PlaywrightException)에 한해 재시도를 선언한다")
     void shouldDeclareRetryOnTransientBrowserExecutors() throws NoSuchMethodException {
-        // 준비: 브라우저를 호출하는 executor 메서드들이 있다
-        // 실행 및 검증: 각 메서드가 동일한 재시도 정책을 가진다
+        // 준비 및 실행/검증: 조회성(멱등) executor는 동일한 재시도 정책을 가진다
         assertRetryable(PlaywrightLoginExecutor.class.getMethod("login", Page.class, LottoUser.class));
-        assertRetryable(PlaywrightPurchaseExecutor.class.getMethod("buy", Page.class, LottoUser.class));
         assertRetryable(PlaywrightResultExecutor.class.getMethod("check", Page.class));
-        assertRetryable(PlaywrightResultExecutor.class.getMethod(
-                "check",
-                Page.class,
-                PurchaseReceipt.class
-        ));
+        assertRetryable(PlaywrightResultExecutor.class.getMethod("check", Page.class, PurchaseReceipt.class));
+    }
+
+    @Test
+    @DisplayName("구매(buy)는 멱등하지 않으므로 재시도를 선언하지 않는다")
+    void shouldNotDeclareRetryOnPurchase() throws NoSuchMethodException {
+        // 준비: 구매 메서드를 조회한다
+        Method buy = PlaywrightPurchaseExecutor.class.getMethod("buy", Page.class, LottoUser.class);
+
+        // 실행 및 검증: 중복 구매 방지를 위해 Retryable을 선언하지 않는다
+        then(buy.getAnnotation(Retryable.class)).isNull();
     }
 
     private void assertRetryable(Method method) {
         Retryable retryable = method.getAnnotation(Retryable.class);
 
         then(retryable).isNotNull();
-        then(retryable.includes()).containsExactly(Exception.class);
+        then(retryable.includes()).containsExactly(PlaywrightException.class);
         then(retryable.maxRetriesString()).isEqualTo("${lotto.max-retries:3}");
         then(retryable.delayString()).isEqualTo("${lotto.retry-delay-ms:2000}");
     }

--- a/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightRetryAnnotationTest.java
+++ b/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightRetryAnnotationTest.java
@@ -3,6 +3,7 @@ package org.nowstart.lotto.adapter.out.browser;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import com.microsoft.playwright.Page;
+import java.util.function.BooleanSupplier;
 import com.microsoft.playwright.PlaywrightException;
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.DisplayName;
@@ -27,7 +28,7 @@ class PlaywrightRetryAnnotationTest {
     @DisplayName("구매(buy)는 멱등하지 않으므로 재시도를 선언하지 않는다")
     void shouldNotDeclareRetryOnPurchase() throws NoSuchMethodException {
         // 준비: 구매 메서드를 조회한다
-        Method buy = PlaywrightPurchaseExecutor.class.getMethod("buy", Page.class, LottoUser.class);
+        Method buy = PlaywrightPurchaseExecutor.class.getMethod("buy", Page.class, LottoUser.class, BooleanSupplier.class);
 
         // 실행 및 검증: 중복 구매 방지를 위해 Retryable을 선언하지 않는다
         then(buy.getAnnotation(Retryable.class)).isNull();

--- a/src/test/java/org/nowstart/lotto/application/service/LottoInteractorTest.java
+++ b/src/test/java/org/nowstart/lotto/application/service/LottoInteractorTest.java
@@ -16,6 +16,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.nowstart.lotto.application.port.in.LottoUseCase.LottoExecution;
 import org.nowstart.lotto.application.port.in.LottoUseCase.TargetCommand;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort;
+import org.nowstart.lotto.config.LottoProperties;
 import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
 import org.nowstart.lotto.domain.exception.InvalidManualUserSelectionException;
 import org.nowstart.lotto.domain.type.ExecutionStatus;
@@ -36,7 +37,7 @@ class LottoInteractorTest {
 
     @BeforeEach
     void setUp() {
-        lottoInteractor = new LottoInteractor(loadLottoUsersPort, lottoUserRunner);
+        lottoInteractor = new LottoInteractor(loadLottoUsersPort, lottoUserRunner, new LottoProperties());
     }
 
     @Test

--- a/src/test/java/org/nowstart/lotto/application/service/LottoInteractorTest.java
+++ b/src/test/java/org/nowstart/lotto/application/service/LottoInteractorTest.java
@@ -2,6 +2,8 @@ package org.nowstart.lotto.application.service;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.assertj.core.api.BDDAssertions.thenThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
 import java.util.List;
@@ -47,8 +49,8 @@ class LottoInteractorTest {
         LottoUser user1 = createUser("user1");
         LottoUser user2 = createUser("user2");
         given(loadLottoUsersPort.loadUsers()).willReturn(List.of(user1, user2));
-        given(lottoUserRunner.runAsync(user1, TaskMode.CHECK)).willReturn(CompletableFuture.completedFuture(true));
-        given(lottoUserRunner.runAsync(user2, TaskMode.CHECK)).willReturn(CompletableFuture.completedFuture(true));
+        given(lottoUserRunner.runAsync(eq(user1), eq(TaskMode.CHECK), any())).willReturn(CompletableFuture.completedFuture(true));
+        given(lottoUserRunner.runAsync(eq(user2), eq(TaskMode.CHECK), any())).willReturn(CompletableFuture.completedFuture(true));
 
         // 실행: 수동 확인 작업을 실행한다
         LottoExecution result = lottoInteractor.check(new TargetCommand(TriggerType.MANUAL, null));
@@ -60,8 +62,8 @@ class LottoInteractorTest {
         then(result.totalUsers()).isEqualTo(2);
         then(result.successUsers()).isEqualTo(2);
         then(result.failedUsers()).isZero();
-        BDDMockito.then(lottoUserRunner).should().runAsync(user1, TaskMode.CHECK);
-        BDDMockito.then(lottoUserRunner).should().runAsync(user2, TaskMode.CHECK);
+        BDDMockito.then(lottoUserRunner).should().runAsync(eq(user1), eq(TaskMode.CHECK), any());
+        BDDMockito.then(lottoUserRunner).should().runAsync(eq(user2), eq(TaskMode.CHECK), any());
     }
 
     @Test
@@ -71,8 +73,8 @@ class LottoInteractorTest {
         LottoUser user1 = createUser("user1");
         LottoUser user2 = createUser("user2");
         given(loadLottoUsersPort.loadUsers()).willReturn(List.of(user1, user2));
-        given(lottoUserRunner.runAsync(user1, TaskMode.PURCHASE)).willReturn(CompletableFuture.completedFuture(true));
-        given(lottoUserRunner.runAsync(user2, TaskMode.PURCHASE)).willReturn(CompletableFuture.completedFuture(false));
+        given(lottoUserRunner.runAsync(eq(user1), eq(TaskMode.PURCHASE), any())).willReturn(CompletableFuture.completedFuture(true));
+        given(lottoUserRunner.runAsync(eq(user2), eq(TaskMode.PURCHASE), any())).willReturn(CompletableFuture.completedFuture(false));
 
         // 실행: 스케줄 구매 작업을 두 사용자에게 실행한다
         LottoExecution result = lottoInteractor.purchase(
@@ -97,7 +99,7 @@ class LottoInteractorTest {
         CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
         failedFuture.completeExceptionally(fatalError);
         given(loadLottoUsersPort.loadUsers()).willReturn(List.of(user));
-        given(lottoUserRunner.runAsync(user, TaskMode.CHECK)).willReturn(failedFuture);
+        given(lottoUserRunner.runAsync(eq(user), eq(TaskMode.CHECK), any())).willReturn(failedFuture);
 
         // 실행 및 검증: 치명적 오류는 실패 카운트로 숨기지 않고 호출자에게 전파한다
         thenThrownBy(() -> lottoInteractor.check(new TargetCommand(TriggerType.MANUAL, null)))
@@ -115,8 +117,8 @@ class LottoInteractorTest {
         CompletableFuture<Boolean> waitingFuture = new CompletableFuture<>();
         fatalFuture.completeExceptionally(fatalError);
         given(loadLottoUsersPort.loadUsers()).willReturn(List.of(user1, user2));
-        given(lottoUserRunner.runAsync(user1, TaskMode.CHECK)).willReturn(fatalFuture);
-        given(lottoUserRunner.runAsync(user2, TaskMode.CHECK)).willReturn(waitingFuture);
+        given(lottoUserRunner.runAsync(eq(user1), eq(TaskMode.CHECK), any())).willReturn(fatalFuture);
+        given(lottoUserRunner.runAsync(eq(user2), eq(TaskMode.CHECK), any())).willReturn(waitingFuture);
 
         // 실행 및 검증: 치명적 오류를 전파하기 전 남은 작업을 best-effort로 취소한다
         thenThrownBy(() -> lottoInteractor.check(new TargetCommand(TriggerType.MANUAL, null)))

--- a/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerSpringTest.java
+++ b/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerSpringTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -46,7 +47,7 @@ class LottoUserAsyncRunnerSpringTest {
         LottoUser user = new LottoUser("user1", "password", 1, "user1@nowstart.org", false);
 
         // 실행: 사용자 작업을 비동기로 요청한다
-        CompletableFuture<Boolean> future = lottoUserRunner.runAsync(user, TaskMode.CHECK);
+        CompletableFuture<Boolean> future = lottoUserRunner.runAsync(user, TaskMode.CHECK, new AtomicBoolean(false));
 
         // 검증: 호출 스레드는 즉시 future를 받고 실제 작업은 다른 스레드에서 진행 중이다
         then(blockingLottoAutomationPort.awaitLoginStarted()).isTrue();

--- a/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerSpringTest.java
+++ b/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerSpringTest.java
@@ -3,6 +3,8 @@ package org.nowstart.lotto.application.service;
 import static org.assertj.core.api.BDDAssertions.then;
 
 import java.util.List;
+import java.util.Optional;
+import java.util.function.BooleanSupplier;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.CountDownLatch;
@@ -107,7 +109,7 @@ class LottoUserAsyncRunnerSpringTest {
         }
 
         @Override
-        public PurchaseReceipt buy(LottoAutomationSession session, LottoUser user) {
+        public Optional<PurchaseReceipt> buy(LottoAutomationSession session, LottoUser user, BooleanSupplier abortRequested) {
             throw new UnsupportedOperationException("purchase is not used in this test");
         }
 

--- a/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerTest.java
+++ b/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerTest.java
@@ -31,6 +31,7 @@ import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
 import org.nowstart.lotto.application.port.out.SendNotificationPort;
 import org.nowstart.lotto.application.port.out.SendNotificationPort.NotificationMessage;
 import org.nowstart.lotto.domain.type.TaskMode;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.springframework.scheduling.annotation.Async;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,7 +65,7 @@ class LottoUserAsyncRunnerTest {
     @DisplayName("사용자 작업 실행 메서드는 lottoTaskExecutor 기반 @Async로 선언한다")
     void shouldDeclareAsyncExecutor() throws NoSuchMethodException {
         // 준비: 사용자별 실행 메서드를 조회한다
-        Method runAsync = LottoUserAsyncRunner.class.getMethod("runAsync", LottoUser.class, TaskMode.class);
+        Method runAsync = LottoUserAsyncRunner.class.getMethod("runAsync", LottoUser.class, TaskMode.class, AtomicBoolean.class);
 
         // 실행 및 검증: Spring Async 프록시가 사용할 executor 이름을 명시한다
         Async async = runAsync.getAnnotation(Async.class);
@@ -85,7 +86,7 @@ class LottoUserAsyncRunnerTest {
                 .willReturn(Optional.of(message));
 
         // 실행: 사용자 확인 작업을 실행한다
-        boolean result = lottoUserAsyncRunner.runAsync(user, TaskMode.CHECK).join();
+        boolean result = lottoUserAsyncRunner.runAsync(user, TaskMode.CHECK, new AtomicBoolean(false)).join();
 
         // 검증: 구매 단계 없이 성공 알림을 전송한다
         then(result).isTrue();
@@ -109,7 +110,7 @@ class LottoUserAsyncRunnerTest {
                 .willReturn(Optional.of(successMessage));
 
         // 실행: 사용자 구매 작업을 실행한다
-        boolean result = lottoUserAsyncRunner.runAsync(user, TaskMode.PURCHASE).join();
+        boolean result = lottoUserAsyncRunner.runAsync(user, TaskMode.PURCHASE, new AtomicBoolean(false)).join();
 
         // 검증: 구매 이후 구매 전용 확인 경로를 타고 성공 알림을 전송한다
         then(result).isTrue();
@@ -133,7 +134,7 @@ class LottoUserAsyncRunnerTest {
                 .willReturn(failureMessage);
 
         // 실행: 사용자 구매 작업을 실행한다
-        boolean result = lottoUserAsyncRunner.runAsync(user, TaskMode.PURCHASE).join();
+        boolean result = lottoUserAsyncRunner.runAsync(user, TaskMode.PURCHASE, new AtomicBoolean(false)).join();
 
         // 검증: 실패 알림을 보내고 실패 결과를 반환한다
         then(result).isFalse();
@@ -149,7 +150,7 @@ class LottoUserAsyncRunnerTest {
         given(lottoAutomationPort.openSession()).willThrow(fatalError);
 
         // 실행 및 검증: 치명적 오류는 호출자에게 전파한다
-        thenThrownBy(() -> lottoUserAsyncRunner.runAsync(user, TaskMode.CHECK).join())
+        thenThrownBy(() -> lottoUserAsyncRunner.runAsync(user, TaskMode.CHECK, new AtomicBoolean(false)).join())
                 .isInstanceOf(OutOfMemoryError.class)
                 .isSameAs(fatalError);
     }

--- a/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerTest.java
+++ b/src/test/java/org/nowstart/lotto/application/service/LottoUserAsyncRunnerTest.java
@@ -90,7 +90,7 @@ class LottoUserAsyncRunnerTest {
 
         // 검증: 구매 단계 없이 성공 알림을 전송한다
         then(result).isTrue();
-        BDDMockito.then(lottoAutomationPort).should(never()).buy(eq(session), any(LottoUser.class));
+        BDDMockito.then(lottoAutomationPort).should(never()).buy(eq(session), any(LottoUser.class), any());
         BDDMockito.then(sendNotificationPort).should(times(1)).send(message);
     }
 
@@ -104,7 +104,7 @@ class LottoUserAsyncRunnerTest {
         NotificationMessage successMessage = new NotificationMessage("success", "numbers", null, "user1@nowstart.org");
         given(lottoAutomationPort.openSession()).willReturn(session);
         given(lottoAutomationPort.login(session, user)).willReturn(new LottoAccountSnapshot("ok", "5000"));
-        given(lottoAutomationPort.buy(session, user)).willReturn(purchaseReceipt);
+        given(lottoAutomationPort.buy(eq(session), eq(user), any())).willReturn(Optional.of(purchaseReceipt));
         given(lottoAutomationPort.check(session, purchaseReceipt)).willReturn(newPurchaseResult);
         given(lottoNotificationFactory.createCheckSuccessMessage(eq(user), any(), any()))
                 .willReturn(Optional.of(successMessage));
@@ -116,7 +116,7 @@ class LottoUserAsyncRunnerTest {
         then(result).isTrue();
         InOrder purchaseOrder = inOrder(lottoAutomationPort);
         BDDMockito.then(lottoAutomationPort).should(purchaseOrder).login(session, user);
-        BDDMockito.then(lottoAutomationPort).should(purchaseOrder).buy(session, user);
+        BDDMockito.then(lottoAutomationPort).should(purchaseOrder).buy(eq(session), eq(user), any());
         BDDMockito.then(lottoAutomationPort).should(purchaseOrder).check(session, purchaseReceipt);
         BDDMockito.then(lottoAutomationPort).should(never()).check(session);
         BDDMockito.then(sendNotificationPort).should(times(1)).send(successMessage);


### PR DESCRIPTION
## 개요

코드 리뷰(자체 + codex 교차검증)에서 도출된 개선 항목을 반영합니다. 실거래(구매) 안전성, 동시성/리소스 안정성, 스케줄러 refresh 정확성을 중심으로 손봤습니다.

> 인증/인가는 서비스 앞단 게이트웨이가 담당하므로 **서비스 내 보안 설정(Spring Security 등)은 이번 범위에서 제외**했습니다.

## 주요 변경

### 실거래 안전성
- **구매 멱등성**: `PlaywrightPurchaseExecutor.buy()`에서 `@Retryable` 제거. 최종 확정 이후 예외 시 재시도가 중복 구매를 유발하던 위험 제거. 반영 여부는 구매 후 원장 확인으로 검증.
- **중복 실행 방지**: `LottoInteractor`에 `mode:userId` 단위 in-flight 가드 추가. 키는 **실제 비동기 작업 종료 시점(`whenComplete`)에만 해제**하여, 호출자 타임아웃 이후 작업이 백그라운드에서 도는 동안 같은 사용자의 중복 실행이 시작되지 않도록 함.

### 동시성 / 안정성
- **동시 세션 상한**: `PlaywrightSessionManager`에 `Semaphore` 도입(`lotto.max-concurrent-sessions`, 기본 3). 가상 스레드가 브라우저 프로세스 수를 제한하지 못하는 문제 보완. permit은 `AtomicBoolean`으로 정확히 1회만 해제.
- **작업 타임아웃**: `lotto.user-task-timeout-ms`(기본 180s)로 사용자 작업 대기 상한. `future.get(timeout)`으로 future를 파괴하지 않고 대기.
- **재시도 범위 축소**: login/결과확인의 `@Retryable includes`를 `PlaywrightException`으로 한정. 인증 실패·로직 오류(NPE 등)·내부 `IllegalStateException`은 재시도하지 않고 실패 통지로 전파.
- **조회 전행 실패 감지**: 결과 확인 시 파싱 가능한 행이 있는데 상세 캡처가 전부 실패하면 예외 처리. selector 변경(사이트 개편)이 "성공(무결과)"로 은폐되지 않도록 함.

### 스케줄러
- 정적 `@Scheduled` → 동적 Trigger(`SchedulingConfigurer`)로 전환. 매 다음 실행 계산 시 현재 `lotto.cron.*`/`lotto.cron.zone`을 다시 읽어, `POST /actuator/refresh` 이후 변경된 cron이 다음 실행부터 반영됨. 타임존을 `lotto.cron.zone`(기본 Asia/Seoul)으로 명시.

### 기타
- 메일 인라인 이미지 `content-type`(image/png) 지정 + 본문 HTML escape + 줄바꿈 처리.
- 로그인 폼 `waitFor` 후 판정(레이스 완화), 구매 결과 다중 후보 매칭 시 경고 로그.
- Playwright 트레이스 기본 비활성화(`lotto.trace-enabled=false`, 민감정보 캡처 방지) 및 정리 대상을 `lotto-trace-*.zip`으로 한정.
- 애플리케이션 버전 `9.2.1 → 9.3.0`.

## 신규 설정 (`lotto.*`)

| Key | 기본값 | 설명 |
|---|---|---|
| `lotto.max-concurrent-sessions` | 3 | 동시 브라우저 세션 상한 |
| `lotto.user-task-timeout-ms` | 180000 | 사용자 작업 대기 상한(ms) |
| `lotto.trace-enabled` | false | Playwright 트레이스 저장 여부 |
| `lotto.cron.zone` | Asia/Seoul | 스케줄러 타임존 |

## 테스트

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test` — 26개 단위/통합 테스트 통과
- [x] 재시도 정책 테스트 갱신: 구매는 재시도하지 않음, login/check는 `PlaywrightException` 한정
- [ ] **스테이징 런타임 검증 필요**(이 변경만으로는 미검증): 실제 구매/로그인/결과확인 브라우저 흐름, 동적 스케줄러 refresh 반영, Semaphore 동시성 상한 동작

## 범위에서 제외 / 후속 과제

- **보안(인증/인가)**: 게이트웨이 담당 → 제외.
- **메일 별도 비동기화**: 이미 사용자별 async 스레드에서 전송되고, 실패 가시성 유지를 위해 동기 유지가 유리 → 미적용.
- **다중 인스턴스 중복 구매 방지**: 현재는 인스턴스 내 가드만. 분산 락/리더 선출은 인프라 필요 → 후속.
- **구매 결과 매칭 완전화**: 현재는 다중 후보 경고까지. 구매 전 원장 스냅샷 기반 정확 매칭은 포트/어댑터 서명 변경 수반 → 후속.
