### PR TITLE
fix: 비밀번호 변경 안내 로그인 처리 (v9.3.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = 'org.nowstart'
-version = '9.3.0'
+version = '9.3.1'
 
 springBoot {
     buildInfo()

--- a/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightLoginExecutor.java
+++ b/src/main/java/org/nowstart/lotto/adapter/out/browser/PlaywrightLoginExecutor.java
@@ -33,15 +33,17 @@ public class PlaywrightLoginExecutor {
             page.click(LottoBrowserConstants.LOGIN_LINK);
         }
 
-        Locator changeLaterLink = page.getByRole(
-                AriaRole.LINK,
+        page.waitForLoadState(LoadState.NETWORKIDLE);
+
+        Locator changeLaterButton = page.getByRole(
+                AriaRole.BUTTON,
                 new Page.GetByRoleOptions().setName(LottoBrowserConstants.CHANGE_LATER)
         );
-        if (changeLaterLink.isVisible()) {
-            changeLaterLink.click();
+        if (changeLaterButton.isVisible()) {
+            changeLaterButton.click();
+            page.waitForLoadState(LoadState.NETWORKIDLE);
         }
 
-        page.waitForLoadState(LoadState.NETWORKIDLE);
         page.navigate(LottoBrowserConstants.URL_MY_PAGE);
 
         LottoAccountSnapshot snapshot = new LottoAccountSnapshot(

--- a/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightLoginExecutorTest.java
+++ b/src/test/java/org/nowstart/lotto/adapter/out/browser/PlaywrightLoginExecutorTest.java
@@ -1,0 +1,63 @@
+package org.nowstart.lotto.adapter.out.browser;
+
+import static org.assertj.core.api.BDDAssertions.then;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+
+import com.microsoft.playwright.Locator;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.options.AriaRole;
+import com.microsoft.playwright.options.LoadState;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.nowstart.lotto.application.port.out.LoadLottoUsersPort.LottoUser;
+import org.nowstart.lotto.application.port.out.LottoAutomationPort.LottoAccountSnapshot;
+
+@DisplayName("Playwright 로그인")
+class PlaywrightLoginExecutorTest {
+
+    private final PlaywrightLoginExecutor playwrightLoginExecutor = new PlaywrightLoginExecutor();
+
+    @Test
+    @DisplayName("로그인 후 비밀번호 변경 안내가 나오면 다음에 변경 버튼을 클릭한다")
+    void shouldSkipPasswordChangeNoticeAfterLogin() {
+        Page page = mock(Page.class);
+        Locator idInput = mock(Locator.class);
+        Locator passwordInput = mock(Locator.class);
+        Locator changeLaterButton = mock(Locator.class);
+        Locator userName = mock(Locator.class);
+        Locator userDeposit = mock(Locator.class);
+        LottoUser user = new LottoUser("user1", "password", 1, "user1@nowstart.org", false);
+
+        given(page.getByPlaceholder(LottoBrowserConstants.ID_INPUT)).willReturn(idInput);
+        given(idInput.isVisible()).willReturn(true);
+        given(page.getByPlaceholder(LottoBrowserConstants.PASSWORD_INPUT)).willReturn(passwordInput);
+        given(page.getByRole(eq(AriaRole.BUTTON), any(Page.GetByRoleOptions.class)))
+                .willReturn(changeLaterButton);
+        given(changeLaterButton.isVisible()).willReturn(true);
+        given(page.locator(LottoBrowserConstants.USER_NAME)).willReturn(userName);
+        given(page.locator(LottoBrowserConstants.USER_DEPOSIT)).willReturn(userDeposit);
+        given(userName.innerText()).willReturn("홍길동");
+        given(userDeposit.innerText()).willReturn("10,000원");
+
+        LottoAccountSnapshot snapshot = playwrightLoginExecutor.login(page, user);
+
+        ArgumentCaptor<Page.GetByRoleOptions> optionsCaptor =
+                ArgumentCaptor.forClass(Page.GetByRoleOptions.class);
+        InOrder noticeHandling = inOrder(page, changeLaterButton);
+        noticeHandling.verify(page).waitForLoadState(LoadState.NETWORKIDLE);
+        noticeHandling.verify(page).getByRole(eq(AriaRole.BUTTON), optionsCaptor.capture());
+        noticeHandling.verify(changeLaterButton).isVisible();
+        noticeHandling.verify(changeLaterButton).click();
+        noticeHandling.verify(page).waitForLoadState(LoadState.NETWORKIDLE);
+
+        then(optionsCaptor.getValue().name).isEqualTo(LottoBrowserConstants.CHANGE_LATER);
+        then(snapshot.name()).isEqualTo("홍길동");
+        then(snapshot.deposit()).isEqualTo("10,000원");
+    }
+}


### PR DESCRIPTION
## 변경 사항

- 로그인 후 장기 미변경 비밀번호 안내에서 `다음에 변경` 버튼을 처리합니다.
- 안내 화면 탐색 전과 버튼 클릭 후 네트워크 안정화를 기다립니다.
- 해당 selector와 대기 순서를 검증하는 회귀 테스트를 추가합니다.
- 프로젝트 버전을 `9.3.0`에서 `9.3.1`로 올립니다.

## 원인

동행복권의 `다음에 변경` 요소가 현재 버튼으로 제공되지만 기존 코드는 링크 역할로 조회했습니다. 이 때문에 안내를 건너뛰지 못하고 마이페이지 접근 시 로그인 화면으로 돌아가 재시도가 반복됐습니다.

## 영향

장기 미변경 비밀번호 안내가 노출되는 계정도 안내를 정상적으로 건너뛰고 로그인 후 작업을 계속합니다.

## 검증

- `./gradlew clean build`
- 27 tests passed
- `git diff --check`
- 독립 코드 리뷰 후 대기 순서 테스트 보강 및 재리뷰 완료